### PR TITLE
sepolicy: Address major display engine denial

### DIFF
--- a/sepolicy/hw_display.te
+++ b/sepolicy/hw_display.te
@@ -1,0 +1,1 @@
+allow hal_displayengine_default displayengine_hwservice:hwservice_manager { add find };


### PR DESCRIPTION
This fixes:

avc:  denied  { add } for interface=vendor.huawei.hardware.hwdisplay.displayengine::IDisplayEngineWrapper pid=14480 scontext=u:r:hal_displayengine_default:s0 tcontext=u:object_r:displayengine_hwservice:s0 tclass=hwservice_manager

And:

avc:  denied  { find } for interface=vendor.huawei.hardware.hwdisplay.displayengine::IDisplayEngineWrapper pid=14475 scontext=u:r:hal_displayengine_default:s0 tcontext=u:object_r:displayengine_hwservice:s0 tclass=hwservice_manager