### PR TITLE
Bluetooth fix for Kirin 65x

### DIFF
--- a/vndk-detect
+++ b/vndk-detect
@@ -10,6 +10,6 @@ while read version;do
 done
 
 mount -o bind /system/bin/adbd /sbin/adbd
-if getprop ro.hardware |grep -q kirin970;then
+if ( getprop ro.hardware | grep -q kirin970 ) || ( getprop ro.hardware | grep -q hi6250 );then
 	setprop persist.sys.bt_acl_bypass true
 fi


### PR DESCRIPTION
BTM_BYPASS_EXTRA_ACL_SETUP has to be true for Kirin 650/659 (aka hi6250) devices.