### PR TITLE
Differentiate QC values for HI6250 and HI36x0 platform

### DIFF
--- a/vndk-detect
+++ b/vndk-detect
@@ -33,6 +33,6 @@ if ( getprop ro.hardware | grep -qE '(hi6250)' );then
 	setprop QC.HI6250 1
 fi
 
-if ( getprop ro.hardware | grep -qE '(hi3660|hi3670)' );then
+if ( getprop ro.hardware | grep -qE '(hi3660|hi3670|kirin970)' );then
 	setprop QC.HI36x0 1
 fi

--- a/vndk-detect
+++ b/vndk-detect
@@ -28,3 +28,11 @@ if getprop ro.hardware |grep -qiE qcom;then
 	FOUND_QCOM=1
 	setprop persist.sys.overlay.devinputjack true
 fi
+
+if ( getprop ro.hardware | grep -qE '(hi6250)' );then
+	setprop QC.HI6250 1
+fi
+
+if ( getprop ro.hardware | grep -qE '(hi3660|hi3670)' );then
+	setprop QC.HI36x0 1
+fi

--- a/vndk.rc
+++ b/vndk.rc
@@ -10,6 +10,12 @@ service phh_service_cleaner /system/bin/service-cleaner.sh
 
 on property:sys.boot_completed=1
     start phh_service_cleaner
-    write /sys/class/hw_power/charger/direct_charger/iin_thermal 4500
-    write /sys/class/hw_power/charger/charge_data/iin_thermal 2000
     exec u:r:phhsu_daemon:s0 root -- /system/bin/bootctl mark-boot-successful
+
+on property:QC.HI6250=1
+   write /sys/class/hw_power/charger/direct_charger/iin_thermal 2750
+   write /sys/class/hw_power/charger/charge_data/iin_thermal 1000
+
+on property:QC.HI36x0=1
+   write /sys/class/hw_power/charger/direct_charger/iin_thermal 4000
+   write /sys/class/hw_power/charger/charge_data/iin_thermal 2000


### PR DESCRIPTION
The previous set values are not compatible over HI6250 platform.
They were causing thermal issues.
This differentiation is needed to avoid the "hot-pan" occurrence.
Tested on ANE-LX1.