### PR TITLE
Add hack to fix Bluetooth audio on LineageOS-based custom roms

### DIFF
--- a/vndk.rc
+++ b/vndk.rc
@@ -4,6 +4,9 @@ on post-fs
 	mount none /system/etc/usb_audio_policy_configuration.xml /vendor/etc/usb_audio_policy_configuration.xml bind
 	export LD_CONFIG_FILE /system/etc/ld.config.${persist.sys.vndk}.txt
 
+	# HACK to fix Bluetooth audio on custom roms
+	mount none /vendor/lost+found /vendor/etc/audio bind
+
 service phh_on_boot /system/bin/phh-on-boot.sh
     oneshot
     disabled


### PR DESCRIPTION
On LineageOS-based custom roms, it prefers to read configs from /vendor/etc/audio/ and fails to load on Treble GSI. 
This hack fixed bluetooth / USB Type-C headset audio on Sharp AQUOS S2.