### PR TITLE
Update lineage.mk for LineageOS 16.0

### DIFF
--- a/lineage.mk
+++ b/lineage.mk
@@ -1,4 +1,3 @@
 $(call inherit-product, vendor/lineage/config/common_full_phone.mk)
-$(call inherit-product, device/lineage/sepolicy/common/sepolicy.mk)
 -include vendor/lineage/build/core/config.mk
 -include vendor/lineage/build/core/apicheck.mk


### PR DESCRIPTION
Remove unnecessary line from `lineage.mk` to be able to build LineageOS 16.0 with dakkar build script.