### PR TITLE
Disable fingerprint "button" on Mi 8

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -54,7 +54,7 @@ changeKeylayout() {
         chmod 0644 /mnt/phh/keylayout/gpio_keys.kl /mnt/phh/keylayout/sec_touchscreen.kl
     fi
 
-    if getprop ro.vendor.build.fingerprint |grep -iq -e xiaomi/polaris -e xiaomi/sirius;then
+    if getprop ro.vendor.build.fingerprint |grep -iq -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper;then
         cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
         chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl
         changed=true


### PR DESCRIPTION
Mi 8 experiences same bug as on Mi Mix 2S and Mi 8 SE