### PR TITLE
Fix fingerprint key for wayne/jasmine

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -54,7 +54,7 @@ changeKeylayout() {
         chmod 0644 /mnt/phh/keylayout/gpio_keys.kl /mnt/phh/keylayout/sec_touchscreen.kl
     fi
 
-    if getprop ro.vendor.build.fingerprint |grep -iq -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper;then
+    if getprop ro.vendor.build.fingerprint |grep -iq -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper -e xiaomi/wayne -e xiaomi/jasmine;then
         cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
         chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl
         changed=true
@@ -63,6 +63,12 @@ changeKeylayout() {
     if [ "$(getprop ro.vendor.product.device)" == "OnePlus6" ];then
         cp /system/phh/oneplus6-synaptics_s3320.kl /mnt/phh/keylayout/synaptics_s3320.kl
         chmod 0644 /mnt/phh/keylayout/synaptics_s3320.kl
+        changed=true
+    fi
+
+    if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/wayne -e xiaomi/jasmine;then
+        cp /system/phh/empty /mnt/phh/keylayout/uinput-fpc.kl
+        chmod 0644 /mnt/phh/keylayout/uinput-fpc.kl
         changed=true
     fi
 


### PR DESCRIPTION
wayne and jasmine has two types fingerprint (fpc and goodix, but goodix fingerprint is still not working)
tested on wayne with aosp 9.0 v106, and it seems working on jasmine, but I don't have it.