### PR TITLE
Stop Huawei's displayengine HAL

### DIFF
--- a/vndk-detect
+++ b/vndk-detect
@@ -23,6 +23,7 @@ if getprop ro.vendor.build.fingerprint |grep -qiE '(huawei|honor|hi3660)' || [ -
 fi
 
 if [ -n "$FOUND_HUAWEI" ];then
+	stop displayengine-hal-1-0
 	setprop debug.hwui.profile true
 fi
 


### PR DESCRIPTION
It's of no use on GSIs and it's "useful" only to spam the logcat, so let's get rid of it.