### PR TITLE
add jasmine_sprout fp (experimental)

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -135,7 +135,7 @@ if getprop ro.vendor.build.fingerprint |grep -q \
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
 fi
 
-if getprop ro.vendor.build.fingerprint |grep -q -i -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout;then
+if getprop ro.vendor.build.fingerprint |grep -q -i -e xiaomi/wayne -e xiaomi/jasmine;then
     setprop persist.imx376_sunny.low.lux 310
     setprop persist.imx376_sunny.light.lux 280
     setprop persist.imx376_ofilm.low.lux 310

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -54,7 +54,7 @@ changeKeylayout() {
         chmod 0644 /mnt/phh/keylayout/gpio_keys.kl /mnt/phh/keylayout/sec_touchscreen.kl
     fi
 
-    if getprop ro.vendor.build.fingerprint |grep -iq -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper -e xiaomi/wayne -e xiaomi/jasmine;then
+    if getprop ro.vendor.build.fingerprint |grep -iq -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout;then
         cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
         chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl
         cp /system/phh/empty /mnt/phh/keylayout/uinput-fpc.kl
@@ -135,7 +135,7 @@ if getprop ro.vendor.build.fingerprint |grep -q \
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
 fi
 
-if getprop ro.vendor.build.fingerprint |grep -q -i -e xiaomi/wayne -e xiaomi/jasmine;then
+if getprop ro.vendor.build.fingerprint |grep -q -i -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout;then
     setprop persist.imx376_sunny.low.lux 310
     setprop persist.imx376_sunny.light.lux 280
     setprop persist.imx376_ofilm.low.lux 310


### PR DESCRIPTION
adding jasmine_sprout (Mi A2) for fingerprint files, should be same hardware as wayne

as per https://github.com/phhusson/treble_experimentations/issues/227