### PR TITLE
Use 28dp statusbar in NoCutout overlay

### DIFF
--- a/overlay/packages/apps/overlays/NoCutoutOverlay/res/values-land/config.xml
+++ b/overlay/packages/apps/overlays/NoCutoutOverlay/res/values-land/config.xml
@@ -16,10 +16,10 @@
 
 <resources>
     <!-- Can't link to other dimensions here, but this should be status_bar_height_landscape -->
-    <dimen name="quick_qs_offset_height">24dp</dimen>
+    <dimen name="quick_qs_offset_height">28dp</dimen>
     <!-- Total height of QQS in landscape; quick_qs_offset_height + 128 -->
-    <dimen name="quick_qs_total_height">152dp</dimen>
+    <dimen name="quick_qs_total_height">156dp</dimen>
     <!-- Because we hardcode status_bar_height in Oreo device overlays,
          we also need to do it here. -->
-    <dimen name="status_bar_height">24dp</dimen>
+    <dimen name="status_bar_height">28dp</dimen>
 </resources>

--- a/overlay/packages/apps/overlays/NoCutoutOverlay/res/values/config.xml
+++ b/overlay/packages/apps/overlays/NoCutoutOverlay/res/values/config.xml
@@ -26,11 +26,11 @@
     <bool name="config_maskMainBuiltInDisplayCutout">true</bool>
 
     <!-- Height of the status bar -->
-    <dimen name="status_bar_height_portrait">24dp</dimen>
-    <dimen name="status_bar_height_landscape">24dp</dimen>
+    <dimen name="status_bar_height_portrait">28dp</dimen>
+    <dimen name="status_bar_height_landscape">28dp</dimen>
     <!-- Because we hardcode status_bar_height in Oreo device overlays,
          we also need to do it here. -->
-    <dimen name="status_bar_height">24dp</dimen>
+    <dimen name="status_bar_height">28dp</dimen>
     <!-- For rounded corners to work, set rounded_corner_radius_bottom or rounded_corner_radius
          in device overlay. -->
     <dimen name="rounded_corner_radius_top">@*android:dimen/rounded_corner_radius_bottom</dimen>


### PR DESCRIPTION
All other cutout emulation overlays use this value and all of the known devices with notch are of 2:1 ratio or higher, so it makes ergonomical sense. Also helps with rounded corners.