### PR TITLE
xiaomi-mimax3-fix

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -68,7 +68,8 @@ changeKeylayout() {
     if getprop ro.vendor.build.fingerprint |grep -iq \
         -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper \
         -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout \
-        -e xiaomi/platina -e iaomi/perseus -e xiaomi/ysl;then
+        -e xiaomi/platina -e iaomi/perseus -e xiaomi/ysl \
+        -e xiaomi/nitrogen;then
         cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
         chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl
         cp /system/phh/empty /mnt/phh/keylayout/uinput-fpc.kl
@@ -162,11 +163,11 @@ if getprop ro.vendor.build.fingerprint |grep -q -i \
     setprop persist.sys.qcom-brightness $(cat /sys/class/leds/lcd-backlight/max_brightness)
 fi
 
-if getprop ro.vendor.build.fingerprint |grep -q \
+if getprop ro.vendor.build.fingerprint |grep -iq \
 	-e Xiaomi/beryllium/beryllium -e Xiaomi/sirius/sirius \
 	-e Xiaomi/dipper/dipper -e Xiaomi/ursa/ursa -e Xiaomi/polaris/polaris \
 	-e motorola/ali/ali -e iaomi/perseus/perseus -e iaomi/platina/platina \
-	-e iaomi/equuleus/equuleus -e motorola/nora;then
+	-e iaomi/equuleus/equuleus -e motorola/nora -e xiaomi/nitrogen;then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
 fi


### PR DESCRIPTION
TL;DR fixes for xiaomi mimax3 vendor fingerprint

Long story:
xiaomi.eu, that is already tested as a base for phh-treble pie gsi, has "polaris" vendor fingerprint for some reason.
This PR makes it possible to apply existing "polaris" fixes that are tested to be fine on current xiaomi.eu, to correct mimax3 vendor fingerprint, - nitrogen.
This shall improve GSI behavior if flashed over stable/beta vendor, as well as future xiaomi.eu vendor, that is supposed to have correct fingerprint some day.