### PR TITLE
Dehardcode status_bar_height in NoCutout overlay

### DIFF
--- a/overlay/packages/apps/overlays/NoCutoutOverlay/res/values-land/config.xml
+++ b/overlay/packages/apps/overlays/NoCutoutOverlay/res/values-land/config.xml
@@ -19,7 +19,4 @@
     <dimen name="quick_qs_offset_height">28dp</dimen>
     <!-- Total height of QQS in landscape; quick_qs_offset_height + 128 -->
     <dimen name="quick_qs_total_height">156dp</dimen>
-    <!-- Because we hardcode status_bar_height in Oreo device overlays,
-         we also need to do it here. -->
-    <dimen name="status_bar_height">28dp</dimen>
 </resources>

--- a/overlay/packages/apps/overlays/NoCutoutOverlay/res/values/config.xml
+++ b/overlay/packages/apps/overlays/NoCutoutOverlay/res/values/config.xml
@@ -28,9 +28,6 @@
     <!-- Height of the status bar -->
     <dimen name="status_bar_height_portrait">28dp</dimen>
     <dimen name="status_bar_height_landscape">28dp</dimen>
-    <!-- Because we hardcode status_bar_height in Oreo device overlays,
-         we also need to do it here. -->
-    <dimen name="status_bar_height">28dp</dimen>
     <!-- For rounded corners to work, set rounded_corner_radius_bottom or rounded_corner_radius
          in device overlay. -->
     <dimen name="rounded_corner_radius_top">@*android:dimen/rounded_corner_radius_bottom</dimen>


### PR DESCRIPTION
As the result of:
https://github.com/phhusson/vendor_hardware_overlay/pull/67