### PR TITLE
Add sakura to fpkey patch

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -70,7 +70,7 @@ changeKeylayout() {
         -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper \
         -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout \
         -e xiaomi/platina -e iaomi/perseus -e xiaomi/ysl \
-        -e xiaomi/nitrogen -e xiaomi/daisy;then
+        -e xiaomi/nitrogen -e xiaomi/daisy -e xiaomi/sakura;then
         cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
         chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl
         cp /system/phh/empty /mnt/phh/keylayout/uinput-fpc.kl


### PR DESCRIPTION
Related #94, but for 9.0 tree.
Seems Redmi 6 pro need this patch, too.