### PR TITLE
rw-system: moto soundfx hack on vndk 27 only

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -164,20 +164,22 @@ if getprop ro.vendor.build.fingerprint |grep -q -i \
     setprop persist.sys.qcom-brightness $(cat /sys/class/leds/lcd-backlight/max_brightness)
 fi
 
-if getprop ro.vendor.build.fingerprint |grep -iq \
-	-e Xiaomi/beryllium/beryllium -e Xiaomi/sirius/sirius \
-	-e Xiaomi/dipper/dipper -e Xiaomi/ursa/ursa -e Xiaomi/polaris/polaris \
-	-e motorola/ali/ali -e iaomi/perseus/perseus -e iaomi/platina/platina \
-	-e iaomi/equuleus/equuleus -e motorola/nora -e xiaomi/nitrogen \
-	-e motorola/hannah;then
-    mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
-    mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
-fi
-
-if [ "$(getprop ro.vendor.product.manufacturer)" == "motorola" ];then
-    if getprop ro.vendor.product.device |grep -q -e nora -e ali -e hannah -e evert -e jeter;then
+if [ "$(getprop ro.vndk.version)" == "27" ];then
+    if getprop ro.vendor.build.fingerprint |grep -iq \
+      	    -e Xiaomi/beryllium/beryllium -e Xiaomi/sirius/sirius \
+            -e Xiaomi/dipper/dipper -e Xiaomi/ursa/ursa -e Xiaomi/polaris/polaris \
+            -e motorola/ali/ali -e iaomi/perseus/perseus -e iaomi/platina/platina \
+            -e iaomi/equuleus/equuleus -e motorola/nora -e xiaomi/nitrogen \
+            -e motorola/hannah;then
         mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
         mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
+    fi
+
+    if [ "$(getprop ro.vendor.product.manufacturer)" == "motorola" ];then
+        if getprop ro.vendor.product.device |grep -q -e nora -e ali -e hannah -e evert -e jeter;then
+            mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
+            mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
+        fi
     fi
 fi
 


### PR DESCRIPTION
Pie vendor on Ali has working audio without this hack, and with the hack fails to boot (audio Hal repeatedly crashes from being unable to load soundfx blobs).