### PR TITLE
gapps.mk: add packages for fi support

### DIFF
--- a/gapps.mk
+++ b/gapps.mk
@@ -17,6 +17,9 @@ PRODUCT_PACKAGES += \
        PrebuiltDeskClockGoogle \
        CalendarGooglePrebuilt \
        LatinImeGoogle \
+       Tycho \
+       CarrierServices \
+       GoogleDialer \
        phh-overrides
 
 $(call inherit-product, vendor/opengapps/build/opengapps-packages.mk)


### PR DESCRIPTION
without these packages built in, fi carrier switching doesn't work.

note: pixels and G6 for instance need additional proprietary
blobs/apps. Rcs also fails to enroll without android messages prebuilt the moment carrier services moves to system.

The only device ready as is I've seen is Moto X4.