### PR TITLE
Decrease system partition size for arm_a images so it fits in for more devices.

### DIFF
--- a/phhgsi_arm_a/BoardConfig.mk
+++ b/phhgsi_arm_a/BoardConfig.mk
@@ -1,4 +1,4 @@
 include build/make/target/board/generic_arm_a/BoardConfig.mk
 include device/phh/treble/board-base.mk
 
-BOARD_SYSTEMIMAGE_PARTITION_SIZE := 1572864000
+BOARD_SYSTEMIMAGE_PARTITION_SIZE := 1313583104


### PR DESCRIPTION
Some Android Go devices have smaller system partition. These devices are not able to flash prebuilt Phh-Treble arm_a image with the original 1.5g values in `BOARD_SYSTEMIMAGE_PARTITION_SIZE`.

The new size should be large enough even for GSI for gapps. (latest Pie treble_arm_agS size is 1251361012)

These are the devices I tried FYI:
Nokia 1 (FRT): 1403305984
Nokia 2.1 (E2M): 1339551744
Asus Zenfone Live L1 (X00RD): 1427771392
Xiaomi Redmi Go (tiare): 1367654400