### PR TITLE
Disable broken led:torch_2 trigger on Mi A2 / Mi 6X

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -203,6 +203,7 @@ if getprop ro.vendor.build.fingerprint | grep -q -i -e xiaomi/wayne -e xiaomi/ja
     setprop persist.imx376_sunny.light.lux 280
     setprop persist.imx376_ofilm.low.lux 310
     setprop persist.imx376_ofilm.light.lux 280
+    echo "none" > /sys/class/leds/led:torch_2/trigger
 fi
 
 for f in /vendor/lib/mtk-ril.so /vendor/lib64/mtk-ril.so /vendor/lib/libmtk-ril.so /vendor/lib64/libmtk-ril.so; do


### PR DESCRIPTION
At the moment, both led:switch_1 and led:torch_2 are both linked to the
front facing camera torch. Xiaomi's stock Pie vendor for devices jasmine
and wayne (Mi A2 and Mi 6X, respectively) mistakingly hooks these nodes
incorrectly, causing the front facing camera torch to default to a
brightness level of 90. However, after a single photo is taken, the
torch turns off temporarily until either A) the camera is closed and
reopened or B) the camera app requests the flash to trigger.

To circumvent the issue with Xiaomi's stock pie vendor blobs, we can
disable the led:torch_2 trigger, and allow led:switch_1 to handle it.

Test: Run the desired command on boot and observe the default front
facing camera torch state.

Test: Ensure Snapchat and Open Camera default to flash being disabled
for the front facing camera torch.

Signed-off-by: Tyler Nijmeh <tylernij@gmail.com>