### PR TITLE
Disable SELINUX_IGNORE_NEVERALLOWS := true for user builds

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -107,7 +107,9 @@ PRODUCT_COPY_FILES += \
 	device/phh/treble/files/samsung-9810-floating_feature.xml:system/ph/sam-9810-flo_feat.xml \
 	device/phh/treble/files/mimix3-gpio-keys.kl:system/phh/mimix3-gpio-keys.kl
 
+ifneq ($(TARGET_BUILD_VARIANT),user)
 SELINUX_IGNORE_NEVERALLOWS := true
+endif
 
 # Universal NoCutoutOverlay
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Build will fail with system/sepolicy/Android.mk:86: error: SELINUX_IGNORE_NEVERALLOWS := true cannot be used in user builds.