### PR TITLE
Add Xiaomi Mi 9 SE for soundfx mess

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -173,7 +173,8 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     -e Xiaomi/dipper/dipper -e Xiaomi/ursa/ursa -e Xiaomi/polaris/polaris \
     -e motorola/ali/ali -e iaomi/perseus/perseus -e iaomi/platina/platina \
     -e iaomi/equuleus/equuleus -e motorola/nora -e xiaomi/nitrogen \
-    -e motorola/hannah -e motorola/james -e motorola/pettyl -e iaomi/cepheus;then
+    -e motorola/hannah -e motorola/james -e motorola/pettyl -e iaomi/cepheus \
+    -e iaomi/grus;then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
 fi


### PR DESCRIPTION
Maybe it's better to use file based detection such as
`[ -f /vendor/lib/soundfx/libvolumelistener.so ] || [ -f /vendor/lib64/soundfx/libvolumelistener.so ]`
for Xiaomi devices since all Xiaomi devices with libvolumelistener.so need this fix...