### PR TITLE
Prevent Brightness Flickering Bug on Redmi Note 7

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -160,7 +160,7 @@ fi
 if getprop ro.vendor.build.fingerprint | grep -q -i \
     -e xiaomi/clover -e xiaomi/wayne -e xiaomi/sakura \
     -e xiaomi/nitrogen -e xiaomi/whyred -e xiaomi/platina \
-    -e xiaomi/ysl -e nubia/nx60 -e nubia/nx61 -e xiaomi/tulip; then
+    -e xiaomi/ysl -e nubia/nx60 -e nubia/nx61 -e xiaomi/tulip -e xiaomi/lavender; then
     setprop persist.sys.qcom-brightness "$(cat /sys/class/leds/lcd-backlight/max_brightness)"
 fi
 


### PR DESCRIPTION
Add the Device to the List, which gets the prop persist.sys.qcom-brightness set.