### PR TITLE
Do not blacklist jasmine and wayne fingerprint gestures

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -68,7 +68,6 @@ changeKeylayout() {
 
     if getprop ro.vendor.build.fingerprint | grep -iq \
         -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper \
-        -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout \
         -e xiaomi/platina -e iaomi/perseus -e xiaomi/ysl \
         -e xiaomi/nitrogen -e xiaomi/daisy -e xiaomi/sakura \
         -e xiaomi/whyred -e xiaomi/tulip; then


### PR DESCRIPTION
These devices to not have problematic behavior with the fingerprint
sensor. Allow these devices to keep their stock configuration.