### PR TITLE
Fix typo

### DIFF
--- a/vndk-detect
+++ b/vndk-detect
@@ -13,7 +13,7 @@ if [ -d /sys/module/five ];then
 	if mount -o bind /system/phh/empty /sbin/adbd;then
 		setprop sys.phh.five true
 	fi
-else if [ -f /sbin/adbd ];then
+elif [ -f /sbin/adbd ];then
 	mount -o bind /system/bin/adbd /sbin/adbd
 fi
 if ( getprop ro.hardware | grep -qE '(kirin970|hi3660|hi6250|hi3670)' );then


### PR DESCRIPTION
shellcheck output below. I don't think these things are needed just right now, you'll probably rework a bit that script later? Or you want me to modifiy smth else? "$version" instead of $version, remove FOUND_QCOM ?

In vndk-detect line 8:
while read version;do
^-- SC2162: read without -r will mangle backslashes.

In vndk-detect line 9:
setprop persist.sys.vndk $version
^-- SC2086: Double quote to prevent globbing and word splitting.

In vndk-detect line 37:
FOUND_QCOM=1
^-- SC2034: FOUND_QCOM appears unused. Verify use (or export if used externally).