### PR TITLE
[daisy] revert camera in DnD fix

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -331,7 +331,7 @@ if getprop ro.vendor.build.fingerprint | grep -qiE '^samsung'; then
     fi
 fi
 
-if getprop ro.vendor.build.fingerprint | grep -qE '^xiaomi/(daisy|wayne)/(daisy|wayne).*'; then
+if getprop ro.vendor.build.fingerprint | grep -qE '^xiaomi/wayne/wayne.*'; then
     # Fix camera on DND, ugly workaround but meh
     setprop audio.camerasound.force true
 fi


### PR DESCRIPTION
  * camera works fine in DnD mode without this fix in v204 and in v121 too
    not need this fix for daisy anymore

	modified:   rw-system.sh