### PR TITLE
Fix for broken OpenGL ES on old Snapdragon devices

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -281,7 +281,8 @@ if grep -qF 'PowerVR Rogue GE8100' /vendor/lib/egl/GLESv1_CM_mtk.so ||
     setprop debug.hwui.renderer opengl
     setprop ro.skia.ignore_swizzle true
     if [ "$vndk" = 26 ] || [ "$vndk" = 27 ];then
-        setprop debug.hwui.profile true
+       setprop debug.hwui.use_buffer_age false
+
     fi
 fi
 


### PR DESCRIPTION
Fix for broken OpenGL ES on old Snapdragon devices
Working in moto e5, please feedback