### PR TITLE
[Pie] [xiaomi] Use persist.sys.phh.xiaomi.dt2w prop to control DT2W

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -57,6 +57,7 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_COPY_FILES += \
 	device/phh/treble/rw-system.sh:system/bin/rw-system.sh \
+	device/phh/treble/phh-prop-handler.sh:system/bin/phh-prop-handler.sh \
 	device/phh/treble/fixSPL/getSPL.arm:system/bin/getSPL
 
 PRODUCT_COPY_FILES += \

--- a/phh-prop-handler.sh
+++ b/phh-prop-handler.sh
@@ -1,0 +1,60 @@
+#!/system/bin/sh
+set -o pipefail
+
+display_usage() {
+    echo -e "\nUsage:\n ./phh-prop-handler.sh [prop]\n"
+}
+
+if [ "$#" -ne 1 ]; then
+    display_usage
+    exit 1
+fi
+
+prop_value=$(getprop "$1")
+
+xiaomi_toggle_dt2w_proc_node() {
+    DT2W_PROC_NODES=("/proc/touchpanel/wakeup_gesture"
+        "/proc/tp_wakeup_gesture"
+        "/proc/tp_gesture")
+    for node in "${DT2W_PROC_NODES[@]}"; do
+        [ ! -f "${node}" ] && continue
+        echo "Trying to set dt2w mode with /proc node: ${node}"
+        echo "$1" >"${node}"
+        [[ "$(cat "${node}")" -eq "$1" ]] # Check result
+        return
+    done
+    return 1
+}
+
+xiaomi_toggle_dt2w_event_node() {
+    for ev in $(
+        cd /sys/class/input || return
+        echo event*
+    ); do
+        [ ! -f "/sys/class/input/${ev}/device/device/gesture_mask" ] &&
+            [ ! -f "/sys/class/input/${ev}/device/wake_gesture" ] && continue
+        echo "Trying to set dt2w mode with event node: /dev/input/${ev}"
+        if [ "$1" -eq 1 ]; then
+            # Enable
+            sendevent /dev/input/"${ev}" 0 1 5
+            return
+        else
+            # Disable
+            sendevent /dev/input/"${ev}" 0 1 4
+            return
+        fi
+    done
+    return 1
+}
+
+if [ "$1" == "persist.sys.phh.xiaomi.dt2w" ]; then
+    if [[ "$prop_value" -ne 0 && "$prop_value" -ne 1 ]]; then
+        exit 1
+    fi
+
+    if ! xiaomi_toggle_dt2w_proc_node "$prop_value"; then
+        # Fallback to event node method
+        xiaomi_toggle_dt2w_event_node "$prop_value"
+    fi
+    exit $?
+fi

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -449,13 +449,6 @@ if [ -c /dev/dsm ];then
     mount /data/sec_storage_data /sec_storage
 fi
 
-#Try to detect DT2W
-for ev in $(cd /sys/class/input;echo event*);do
-	if [ -f "/sys/class/input/$ev/device/device/gesture_mask" ];then
-		setprop persist.sys.phh.dt2w_evnode /dev/input/$ev
-	fi
-done
-
 has_hostapd=false
 for i in odm oem vendor product;do
     if grep -qF android.hardware.wifi.hostapd /$i/etc/vintf/manifest.xml;then

--- a/vndk.rc
+++ b/vndk.rc
@@ -15,3 +15,6 @@ on property:sys.boot_completed=1
 
 on property:persist.sys.phh.mainkeys=*
     setprop qemu.hw.mainkeys ${persist.sys.phh.mainkeys}
+
+on property:persist.sys.phh.xiaomi.dt2w=*
+    exec_background u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.xiaomi.dt2w"


### PR DESCRIPTION
On stock kernel, the /proc gesture nodes are created to control DT2W
whyred: https://github.com/MiCode/Xiaomi_Kernel_OpenSource/blob/tulip-p-oss/drivers/input/touchscreen/lct_tp_gesture.c#L98
daisy: https://github.com/MiCode/Xiaomi_Kernel_OpenSource/blob/daisy-p-oss/drivers/input/touchscreen/gt917d/gt9xx.c#L1795

We can write "1" to these /proc nodes to enable DT2W and "0" to disable it

Related PR: https://github.com/phhusson/treble_app/pull/21