### PR TITLE
[daisy] revert camera in DnD fix

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -364,7 +364,7 @@ if getprop ro.vendor.build.fingerprint | grep -qiE '^samsung'; then
     fi
 fi
 
-if getprop ro.vendor.build.fingerprint | grep -qE '^xiaomi/(daisy|wayne)/(daisy|wayne).*'; then
+if getprop ro.vendor.build.fingerprint | grep -qE '^xiaomi/wayne/wayne.*'; then
     # Fix camera on DND, ugly workaround but meh
     setprop audio.camerasound.force true
 fi

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -317,6 +317,11 @@ if getprop ro.vendor.product.device | grep -q -e nora -e rhannah; then
     setprop debug.sf.latch_unsignaled 1
 fi
 
+if getprop ro.vendor.build.fingerprint | grep -iq -e xiaomi/daisy; then
+    setprop debug.sf.latch_unsignaled 1
+    setprop debug.sf.enable_hwc_vds 1
+fi
+
 if getprop ro.vendor.build.fingerprint | grep -iq -E -e 'huawei|honor' || getprop persist.sys.overlay.huawei | grep -iq -E -e 'true'; then
     p=/product/etc/nfc/libnfc_nxp_*_*.conf
     mount -o bind "$p" /system/etc/libnfc-nxp.conf ||


### PR DESCRIPTION
  * camera works fine in DnD mode without this fix in v204 and in v121 too
    not need this fix for daisy anymore

	modified:   rw-system.sh