### PR TITLE
rw-system: disable hardware acceleration in system_server for SPRD devices

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -530,4 +530,8 @@ if [ -e /dev/sprd-adf-dev ];then
     mknod -m666 /dev/adf-interface0.0 c 250 1
     mknod -m666 /dev/adf-overlay-engine0.0 c 250 2
     restorecon /dev/adf0 /dev/adf-interface0.0 /dev/adf-overlay-engine0.0
+
+    # SPRD GL causes crashes in system_server (not currently observed in other processes)
+    # Tell the system to avoid using hardware acceleration in system_server.
+    setprop ro.config.avoid_gfx_accel true
 fi


### PR DESCRIPTION
* For some reason, the OpenGL implementation on SPRD devices causes
  crashes in system_server on glFinish() due to double-free of mutexes.
  It is not the same case with the MTK skia compatibility bug, because
  this one produces no GL errors, only the final mutex-related crash.
* This crash is only observed in system_server by far. In other
  hardware-accelerated applications, after a lot of tinkering, I could
  not reproduce the same problem. (Even if they somehow do crash, it
  won't bring the entire system down like `system_server`.)
* Since all SPRD devices do not have "high-end gfx", it is reasonable
  to set this `ro.config.avoid_gfx_accel` flag. This will disable the
  use of hardware gfx in system_server, avoiding the crash. Most SPRD
  devices comes with Android Go by default, which has this flag set
  (implied by `ro.config.low_ram`) anyway.
* All devices having the `sprd-adf` module is an SPRD device launched
  with Android 9 or earlier. ADF is deprecated in Android 10 or higher.