### PR TITLE
[Android 10] [xiaomi] Use persist.sys.phh.xiaomi.dt2w prop to control DT2W

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -56,6 +56,7 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_COPY_FILES += \
 	device/phh/treble/rw-system.sh:system/bin/rw-system.sh \
+	device/phh/treble/phh-prop-handler.sh:system/bin/phh-prop-handler.sh \
 	device/phh/treble/fixSPL/getSPL.arm:system/bin/getSPL
 
 PRODUCT_COPY_FILES += \

--- a/phh-prop-handler.sh
+++ b/phh-prop-handler.sh
@@ -1,0 +1,60 @@
+#!/system/bin/sh
+set -o pipefail
+
+display_usage() {
+    echo -e "\nUsage:\n ./phh-prop-handler.sh [prop]\n"
+}
+
+if [ "$#" -ne 1 ]; then
+    display_usage
+    exit 1
+fi
+
+prop_value=$(getprop "$1")
+
+xiaomi_toggle_dt2w_proc_node() {
+    DT2W_PROC_NODES=("/proc/touchpanel/wakeup_gesture"
+        "/proc/tp_wakeup_gesture"
+        "/proc/tp_gesture")
+    for node in "${DT2W_PROC_NODES[@]}"; do
+        [ ! -f "${node}" ] && continue
+        echo "Trying to set dt2w mode with /proc node: ${node}"
+        echo "$1" >"${node}"
+        [[ "$(cat "${node}")" -eq "$1" ]] # Check result
+        return
+    done
+    return 1
+}
+
+xiaomi_toggle_dt2w_event_node() {
+    for ev in $(
+        cd /sys/class/input || return
+        echo event*
+    ); do
+        [ ! -f "/sys/class/input/${ev}/device/device/gesture_mask" ] &&
+            [ ! -f "/sys/class/input/${ev}/device/wake_gesture" ] && continue
+        echo "Trying to set dt2w mode with event node: /dev/input/${ev}"
+        if [ "$1" -eq 1 ]; then
+            # Enable
+            sendevent /dev/input/"${ev}" 0 1 5
+            return
+        else
+            # Disable
+            sendevent /dev/input/"${ev}" 0 1 4
+            return
+        fi
+    done
+    return 1
+}
+
+if [ "$1" == "persist.sys.phh.xiaomi.dt2w" ]; then
+    if [[ "$prop_value" -ne 0 && "$prop_value" -ne 1 ]]; then
+        exit 1
+    fi
+
+    if ! xiaomi_toggle_dt2w_proc_node "$prop_value"; then
+        # Fallback to event node method
+        xiaomi_toggle_dt2w_event_node "$prop_value"
+    fi
+    exit $?
+fi

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -580,13 +580,6 @@ if [ -c /dev/dsm ];then
     fi
 fi
 
-#Try to detect DT2W
-for ev in $(cd /sys/class/input;echo event*);do
-	if [ -f "/sys/class/input/$ev/device/device/gesture_mask" ];then
-		setprop persist.sys.phh.dt2w_evnode /dev/input/$ev
-	fi
-done
-
 has_hostapd=false
 for i in odm oem vendor product;do
     if grep -qF android.hardware.wifi.hostapd /$i/etc/vintf/manifest.xml;then

--- a/sepolicy/treble_app.te
+++ b/sepolicy/treble_app.te
@@ -8,10 +8,6 @@ allow system_app sysfs_batteryinfo:file rw_file_perms;
 type vendor_camera_prop, property_type;
 set_prop(system_app, vendor_camera_prop);
 
-#Used to control double-tap-to-wake on Xiaomi
-allow system_app input_device:chr_file rw_file_perms;
-allow system_app input_device:dir r_dir_perms;
-
 type hal_ext_fingerprint_hwservice, hwservice_manager_type;
 allow system_app hal_ext_fingerprint_hwservice:hwservice_manager { find };
 type hal_fingerprint_default, domain;

--- a/vndk.rc
+++ b/vndk.rc
@@ -26,3 +26,5 @@ on property:persist.sys.phh.oppo.gaming_mode=*
 on property:persist.sys.phh.oppo.usbotg=*
     exec_background u:r:phhsu_daemon:s0 root -- /system/bin/sh -c "echo ${persist.sys.phh.oppo.usbotg} > /sys/class/power_supply/usb/otg_switch"
 
+on property:persist.sys.phh.xiaomi.dt2w=*
+    exec_background u:r:phhsu_daemon:s0 root -- /system/bin/phh-prop-handler.sh "persist.sys.phh.xiaomi.dt2w"


### PR DESCRIPTION
Android 10 equivalent of https://github.com/phhusson/device_phh_treble/pull/139

Tested on **whyred** with both OSS kernel and stock kernel on P Vendor.