### PR TITLE
Add Redmi 7 - onc(lite) to fingerprint input events blacklist

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -72,7 +72,7 @@ changeKeylayout() {
         -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout \
         -e xiaomi/platina -e iaomi/perseus -e xiaomi/ysl \
         -e xiaomi/nitrogen -e xiaomi/daisy -e xiaomi/sakura \
-        -e xiaomi/whyred -e xiaomi/tulip; then
+        -e xiaomi/whyred -e xiaomi/tulip -e xiaomi/onc; then
         if [ ! -f /mnt/phh/keylayout/uinput-goodix.kl ]; then
           cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
           chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl


### PR DESCRIPTION
This was causing generation of unwanted tap events upon fingerprint touches.