### PR TITLE
Enable latch_unsignaled on exynos devices

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -305,7 +305,7 @@ if busybox_phh unzip -p /vendor/app/ims/ims.apk classes.dex | grep -qF -e Landro
     mount -o bind /system/phh/empty /vendor/app/ims/ims.apk
 fi
 
-if getprop ro.hardware | grep -qF samsungexynos; then
+if getprop ro.hardware | grep -qF samsungexynos -e exynos; then
     setprop debug.sf.latch_unsignaled 1
 fi
 


### PR DESCRIPTION
ro.hardware=exynos* on some samsung devices
eg. Samsung Galaxy M20