### PR TITLE
Disable audio effects for Motorola Moto G7 Play

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -257,6 +257,13 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     setprop  ro.audio.ignore_effects true
 fi
 
+if getprop ro.build.fingerprint | grep -iq \
+    -e motorola/channel; then
+    mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
+    mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
+    setprop ro.audio.ignore_effects true
+fi
+
 if [ "$(getprop ro.vendor.product.manufacturer)" = "motorola" ] || [ "$(getprop ro.product.vendor.manufacturer)" = "motorola" ]; then
     if getprop ro.vendor.product.device | grep -q -e nora -e ali -e hannah -e evert -e jeter -e deen -e james -e pettyl -e jater; then
         if [ "$vndk" -ge 28 ]; then


### PR DESCRIPTION
This disables audio effects for the Motorola Moto G7 Play (channel) as
enabled audio effects break audio via Bluetooth.

It requires a separate if-statement in `rw-system.sh`, because
`ro.vendor.build.fingerprint` isn't set for the device.

Relates to: https://github.com/phhusson/treble_experimentations/issues/857

I'd love to fix this for the other known affected devices (G6, G6Play, One) as well, but I'm not sure how this interacts with the following code in `rw-system.sh`: https://github.com/phhusson/device_phh_treble/blob/04583fa95a6c58d25dda7644002f9da05eee3ab2/rw-system.sh#L260-L279