### PR TITLE
Fix fingerprint

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -529,26 +529,32 @@ if getprop ro.boot.boot_devices |grep -v , |grep -qE .;then
 fi
 
 if [ -c /dev/dsm ];then
-		# /dev/dsm is a magic device on Kirin chipsets that teecd needs to access.
-		# Make sure that permissions are right.
+    # /dev/dsm is a magic device on Kirin chipsets that teecd needs to access.
+    # Make sure that permissions are right.
     chown system:system /dev/dsm
     chmod 0660 /dev/dsm
 
-		# The presence of /dev/dsm indicates that we have a teecd, which needs /sec_storage
+    # The presence of /dev/dsm indicates that we have a teecd,
+    # which needs /sec_storage and /data/sec_storage_data
 
-		mount | grep " on /sec_storage " > /dev/null 2>&1
-		if [ "$?" -eq "0" ]; then
-				# /sec_storage is already mounted by the vendor, don't try to create and mount it
-				# ourselves. However, some devices have /sec_storage owned by root, which means that
-				# the fingerprint daemon (running as system) cannot access it.
-				chown -R system:system /sec_storage
-				chmod -R 0660 /sec_storage
-		else
-				# No /sec_storage provided by vendor, create our own
-				mkdir -p /data/sec_storage_data
-				chown system:system /data/sec_storage_data
-				mount /data/sec_storage_data /sec_storage
-		fi
+    mkdir -p /data/sec_storage_data
+    chown system:system /data/sec_storage_data
+    chcon -R u:object_r:teecd_data_file:s0 /data/sec_storage_data
+
+    mount | grep " on /sec_storage " > /dev/null 2>&1
+    if [ "$?" -eq "0" ]; then
+        # /sec_storage is already mounted by the vendor, don't try to create and mount it
+        # ourselves. However, some devices have /sec_storage owned by root, which means that
+        # the fingerprint daemon (running as system) cannot access it.
+        chown -R system:system /sec_storage
+        chmod -R 0660 /sec_storage
+        chcon -R u:object_r:teecd_data_file:s0 /sec_storage
+    else
+        # No /sec_storage provided by vendor, mount /data/sec_storage_data to it
+        mount /data/sec_storage_data /sec_storage
+        chown system:system /sec_storage
+        chcon u:object_r:teecd_data_file:s0 /sec_storage
+    fi
 fi
 
 #Try to detect DT2W

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -541,8 +541,7 @@ if [ -c /dev/dsm ];then
     chown system:system /data/sec_storage_data
     chcon -R u:object_r:teecd_data_file:s0 /data/sec_storage_data
 
-    mount | grep " on /sec_storage " > /dev/null 2>&1
-    if [ "$?" -eq "0" ]; then
+    if mount | grep -q " on /sec_storage " ; then
         # /sec_storage is already mounted by the vendor, don't try to create and mount it
         # ourselves. However, some devices have /sec_storage owned by root, which means that
         # the fingerprint daemon (running as system) cannot access it.


### PR DESCRIPTION
This is an attempt to fix https://github.com/phhusson/treble_experimentations/issues/1036 (fingerprints not working on certain Huawei devices).

The problem seems to be bogus permissions and mounts on `/sec_storage` and `/data/sec_storage_data`. I'm not sure whether I figured out the way these two interact correctly. Here is my assumption (which should be reflected by this patch):

* All Huawei devices (running `teecd` to interact with secure storage) need the folder `/data/sec_storage_data` to be present and to be read-/writeable for `teecd` and `vendor.huawei.hardware.biometrics.fingerprint@2.1-service`. 
* On some devices (such as mine), `/sec_storage` is mounted by the vendor to some dedicated partition. In this case, the permissions for `/sec_storage` might be set in a way such that the fingerprint service cannot access them. Therefore, we adapt the permissions of the directory in this case.
* On some devices (which the original script worked for?), `/sec_storage` in not mounted anywhere by the vendor, in which case we just mount it to `/data/sec_storage_data`. We still need to make sure the permissions of the mount point are correct.

I hope this about covers it. With this `rw-system.sh`, fingerprints work on my device with the latest AOSP 10 build.