### PR TITLE
Fix dt2w for Lenovo Z5s

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -127,6 +127,8 @@ changeKeylayout() {
     if getprop ro.vendor.build.fingerprint |grep -iq -E -e '^Lenovo/' && [ -f /sys/devices/virtual/touch/tp_dev/gesture_on ];then
         cp /system/phh/lenovo-synaptics_dsx.kl /mnt/phh/keylayout/synaptics_dsx.kl
         chmod 0644 /mnt/phh/keylayout/synaptics_dsx.kl
+        cp /system/phh/lenovo-synaptics_dsx.kl /mnt/phh/keylayout/fts_ts.kl
+        chmod 0644 /mnt/phh/keylayout/fts_ts.kl
         changed=true
     fi
 


### PR DESCRIPTION
Fixing dt2w for `Lenovo Z5s` aka `jd2019` aka `L78071`. Probably fixes it for the `Lenovo Z5` aswell.
Ref:
https://github.com/phhusson/treble_experimentations/issues/841
https://github.com/phhusson/treble_experimentations/issues/1173