### PR TITLE
fix brightness flickering for Lenovo Z5s

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -217,6 +217,12 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     setprop persist.sys.qcom-brightness -1
 fi
 
+# Lenovo Z5s brightness flickers without this setting
+if getprop ro.vendor.build.fingerprint | grep -iq \
+    -e Lenovo/jd2019; then
+    setprop persist.sys.qcom-brightness -1
+fi
+
 if getprop ro.vendor.build.fingerprint | grep -qi oneplus/oneplus6/oneplus6; then
     resize2fs /dev/block/platform/soc/1d84000.ufshc/by-name/userdata
 fi


### PR DESCRIPTION
Fixes the brightness flickering issue for the Lenovo Z5s. Might need to be applied to other Lenovo phones aswell, remains to be seen.

ref:
https://github.com/phhusson/vendor_hardware_overlay/pull/139
https://github.com/phhusson/treble_experimentations/issues/1173