### PR TITLE
Enable links to cell broadcast app

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -34,4 +34,6 @@
 	<bool name="config_smart_battery_available">true</bool>
 	<dimen name="config_dialogCornerRadius">8.0dip</dimen>
 	<dimen name="config_buttonCornerRadius">4.0dip</dimen>
+
+	<bool name="config_cellBroadcastAppLinks">true</bool>
 </resources>


### PR DESCRIPTION
This enables links from the settings to the cell broadcast app for
configuring the behavior for received cell broadcasts.

While most hardware overlays already enabled this setting, it's nothing
hardware related, so it makes sense to set here globally for any device.

I'll also open a PR in `vendor_hardware_overlay` to remove the setting
from all overlays there.