### PR TITLE
Re-enable multi user for all devices

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -24,10 +24,8 @@
 
 	<string name="config_wallpaperCropperPackage">com.android.wallpaperpicker</string>
 	<bool name="config_unplugTurnsOnScreen">true</bool>
-	<!-- Currently disabled for Android Go
-	<integer name="config_multiuserMaximumUsers">4</integer>
+	<integer name="config_multiuserMaximumUsers">5</integer>
 	<bool name="config_enableMultiUserUI">true</bool>
-	-->
 
 	<string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
 	<bool name="config_swipe_up_gesture_setting_available">true</bool>


### PR DESCRIPTION
This commit re-enables multiple users for all devices. That's possible
as the system image is too large for Android Go nowadays anyway,
therefore no Android Go builds are available anymore.

This commit also increases the maximum number of users from 4 to 5 as
that's what several hardware already overlays set.