### PR TITLE
Fix brightness flickering and solve low brightness level in Lenovo Z5s (jd2019)

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -220,7 +220,7 @@ fi
 # Lenovo Z5s brightness flickers without this setting
 if getprop ro.vendor.build.fingerprint | grep -iq \
     -e Lenovo/jd2019; then
-    setprop persist.sys.qcom-brightness -1
+    setprop persist.sys.qcom-brightness 4095
 fi
 
 if getprop ro.vendor.build.fingerprint | grep -qi oneplus/oneplus6/oneplus6; then


### PR DESCRIPTION
Brightness level goes dark as stock rom now
phhusson/treble_experimentations#1173