### PR TITLE
[Mi Mix 3 5G/andromeda] Fix Fingerprint Issue

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -86,7 +86,7 @@ changeKeylayout() {
         -e xiaomi/polaris -e xiaomi/sirius -e xiaomi/dipper \
         -e xiaomi/wayne -e xiaomi/jasmine -e xiaomi/jasmine_sprout \
         -e xiaomi/platina -e iaomi/perseus -e xiaomi/ysl -e Redmi/begonia\
-        -e xiaomi/nitrogen -e xiaomi/daisy -e xiaomi/sakura \
+        -e xiaomi/nitrogen -e xiaomi/daisy -e xiaomi/sakura -e xiaomi/andromeda \
         -e xiaomi/whyred -e xiaomi/tulip -e xiaomi/onc; then
         if [ ! -f /mnt/phh/keylayout/uinput-goodix.kl ]; then
           cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl


### PR DESCRIPTION
Add `uinput-goodix.kl` and `uinput-fpc.kl` to `xiaomi/andromeda`.

Tested on my device by putting both files under `/system/usr/keylayout`.

Ref: https://forum.xda-developers.com/showpost.php?p=82179105&postcount=731