### PR TITLE
[Mi Mix 3 5G/andromeda] Fix Audio Issue

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -267,7 +267,7 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     -e iaomi/equuleus/equuleus -e motorola/nora -e xiaomi/nitrogen \
     -e motorola/hannah -e motorola/james -e motorola/pettyl -e iaomi/cepheus \
     -e iaomi/grus -e xiaomi/cereus -e iaomi/raphael -e iaomi/davinci \
-    -e iaomi/ginkgo -e iaomi/laurel_sprout;then
+    -e iaomi/ginkgo -e iaomi/laurel_sprout -e xiaomi/andromeda; then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
     setprop  ro.audio.ignore_effects true


### PR DESCRIPTION
Set `ro.audio.ignore_effects` to `true` for `xiaomi/andromeda`.

Tested on my device by adding it to the `build.prop`.

Ref: https://forum.xda-developers.com/showpost.php?p=82126487&postcount=697