### PR TITLE
rw-system: Enforce vendor media_profiles on PL2

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -655,3 +655,7 @@ if getprop ro.omc.build.version |grep -qE .;then
 		mount /system/phh/empty $f
 	done
 fi
+
+if getprop ro.vendor.build.fingerprint |grep -qiE -e Nokia/Plate2; then
+    setprop media.settings.xml "/vendor/etc/media_profiles_vendor.xml"
+fi


### PR DESCRIPTION
*This fixes https://github.com/phhusson/treble_experimentations/issues/379

Signed-off-by: theimpulson <aayushgupta219@gmail.com>