### PR TITLE
Fix exynos grep command to apply setprop correctly

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -270,11 +270,11 @@ if getprop ro.vendor.build.fingerprint | grep -q -i \
     setprop persist.sys.qcom-brightness "$(cat /sys/class/leds/lcd-backlight/max_brightness)"
 fi
 
-if getprop ro.vendor.product.device |grep -iq -e RMX1801 -e RMX1803 -e RMX1807;then	
+if getprop ro.vendor.product.device |grep -iq -e RMX1801 -e RMX1803 -e RMX1807;then
     setprop persist.sys.qcom-brightness "$(cat /sys/class/leds/lcd-backlight/max_brightness)"
 fi
 
-if getprop ro.build.overlay.deviceid |grep -q -e CPH1859 -e CPH1861 -e RMX1811;then	
+if getprop ro.build.overlay.deviceid |grep -q -e CPH1859 -e CPH1861 -e RMX1811;then
     setprop persist.sys.qcom-brightness "$(cat /sys/class/leds/lcd-backlight/max_brightness)"
 fi
 
@@ -386,14 +386,14 @@ if busybox_phh unzip -p /vendor/app/ims/ims.apk classes.dex | grep -qF -e Landro
     mount -o bind /system/phh/empty /vendor/app/ims/ims.apk
 fi
 
-if getprop ro.hardware | grep -q -e samsungexynos -e exynos; then
+if getprop ro.hardware | grep -qF exynos; then
     setprop debug.sf.latch_unsignaled 1
 fi
 
 if getprop ro.product.model | grep -qF ANE; then
     setprop debug.sf.latch_unsignaled 1
 fi
-        
+
 if getprop ro.vendor.product.device | grep -q -e nora -e rhannah; then
     setprop debug.sf.latch_unsignaled 1
 fi

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -386,7 +386,7 @@ if busybox_phh unzip -p /vendor/app/ims/ims.apk classes.dex | grep -qF -e Landro
     mount -o bind /system/phh/empty /vendor/app/ims/ims.apk
 fi
 
-if getprop ro.hardware | grep -qF samsungexynos -e exynos; then
+if getprop ro.hardware | grep -q -e samsungexynos -e exynos; then
     setprop debug.sf.latch_unsignaled 1
 fi
 


### PR DESCRIPTION
Was this grep command even tested?
On my Exynos device with a ro.hardware property as "exynos7904", the setprop command is not being applied at all...

If I run the command using adb shell, the output is:
`
$ getprop ro.hardware | grep -qF samsungexynos -e exynos
`
`
grep: samsungexynos: No such file or directory
`

No problem occurs if "samsungexynos" is the only argument of grep.
So, I believe, we should have the same command as "nora" and "rhannah" have a few lines below.
Something like:
`
$ getprop ro.hardware | grep -q -e samsungexynos -e exynos
`

Right?

The same pull request was made on the android-9.0 branch.