### PR TITLE
Scan in /odm/etc/vintf for fingerprint sensor data

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -250,7 +250,7 @@ if grep vendor.huawei.hardware.biometrics.fingerprint /vendor/manifest.xml; then
 fi
 
 foundFingerprint=false
-for manifest in /vendor/manifest.xml /vendor/etc/vintf/manifest.xml;do
+for manifest in /vendor/manifest.xml /vendor/etc/vintf/manifest.xml /odm/etc/vintf/manifest.xml;do
     if grep -q -e android.hardware.biometrics.fingerprint -e vendor.oppo.hardware.biometrics.fingerprint $manifest;then
         foundFingerprint=true
     fi


### PR DESCRIPTION
The manifest.xml for specifying the fingerprint sensor for the Fairphone 3 (SW-version 8901.3.A.0066.20201119) is located at /odm/etc/vintf/. This path is currently not scanned for manifest files. This proposed change includes this missing path an enables to use the fingerprint sensor on the FP3.