### PR TITLE
Add Redmi/joyeuse to changeKeyLayout

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -144,7 +144,7 @@ changeKeylayout() {
         -e xiaomi/nitrogen -e xiaomi/sakura -e xiaomi/andromeda \
         -e xiaomi/whyred -e xiaomi/tulip -e xiaomi/onc \
         -e redmi/curtana -e redmi/picasso -e Redmi/lancelot \
-        -e Redmi/galahad -e xiaomi/olive -e Redmi/angelica ; then
+        -e Redmi/galahad -e xiaomi/olive -e Redmi/angelica -e Redmi/joyeuse ; then
         if [ ! -f /mnt/phh/keylayout/uinput-goodix.kl ]; then
           cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
           chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl


### PR DESCRIPTION
Fixes random touches on Redmi Note 9 Pro `joyeuse` when fingerprint is pressed