### PR TITLE
sepolicy/treble_app: add rule fix cam2api option

### DIFF
--- a/sepolicy/treble_app.te
+++ b/sepolicy/treble_app.te
@@ -24,6 +24,8 @@ allow system_app default_hisi_hwservice:hwservice_manager { find };
 type hal_tp_default, domain;
 allow system_app hal_tp_default:binder { call };
 
+#cam2api
+allow system_app vendor_default_prop:property_service { set };
 
 set_prop(system_app, default_prop);
 set_prop(system_app, exported3_default_prop);


### PR DESCRIPTION
  logs:
      17 00:47:48.796     1     1 W /system/bin/init: type=1107
      audit(0.0:357): uid=0 auid=4294967295 ses=4294967295
      subj=u:r:init:s0 msg='avc: denied { set } for
      property=persist.vendor.camera.eis.enable pid=4411 uid=1000
      gid=1000 scontext=u:r:system_app:s0
      tcontext=u:object_r:vendor_default_prop:s0 tclass=property_service
      permissive=0'

      01-17 00:47:48.796     1     1 W /system/bin/init: type=1107
      audit(0.0:356): uid=0 auid=4294967295 ses=4294967295
      subj=u:r:init:s0 msg='avc: denied { set } for
      property=persist.vendor.camera.HAL3.enabled pid=4411 uid=1000
      gid=1000 scontext=u:r:system_app:s0
      tcontext=u:object_r:vendor_default_prop:s0 tclass=property_service
      permissive=0'