### PR TITLE
fix gapps build

### DIFF
--- a/gapps.mk
+++ b/gapps.mk
@@ -16,22 +16,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES := $(filter-out ro.boot.vendor.overlay.theme=%,$(PRODUCT_SYSTEM_DEFAULT_PROPERTIES))
 endif
 
-ifneq ($(wildcard vendor/partner_gms),)
--include vendor/partner_gms/products/gms.mk
-PRODUCT_SHIPPING_API_LEVEL :=
-
-PRODUCT_PACKAGES := $(filter-out CalendarGoogle, $(PRODUCT_PACKAGES))
-PRODUCT_PACKAGES := $(filter-out GoogleContacts, $(PRODUCT_PACKAGES))
-
-PRODUCT_PACKAGES += \
-	phh-gapps-overrides \
-	Chrome \
-	GoogleContactsSyncAdapter \
-	talkback \
-
-PRODUCT_SYSTEM_DEFAULT_PROPERTIES := $(filter-out ro.boot.vendor.overlay.theme=%,$(PRODUCT_SYSTEM_DEFAULT_PROPERTIES))
-endif
-
 ifneq ($(wildcard vendor/opengapps),)
 PRODUCT_COPY_FILES += \
 	device/phh/treble/empty-permission.xml:system/etc/permissions/com.google.android.camera2.xml \


### PR DESCRIPTION
  remove commit trash after
  https://github.com/phhusson/device_phh_treble/commit/b2eea56e6c2c14878029acf69a35ebf3fd9bf7de

  FAILED:
  build/make/core/aapt2.mk:33: error: overriding commands for target
  `out/target/common/obj/APPS/SettingsProvider__auto_generated_rro_product_intermediates/flat-res/vendor/partner_gms/overlay/gms_overlay/frameworks/base/packages/SettingsProvider/res/values_defaults.arsc.flat',
  previously defined at build/make/core/aapt2.mk:27
  23:03:05 ckati failed with: exit status 1