### PR TITLE
Fix Some SELinux Denials On Samsung A6+ 2018

### DIFF
--- a/sepolicy/samsung.te
+++ b/sepolicy/samsung.te
@@ -2,5 +2,3 @@ type boot_prop, property_type;
 
 set_prop(system_server, boot_prop);
 
-allow hal_camera_default system_prop:property_service { set }
-allow kernel sysfs:file { read open }

--- a/sepolicy/samsung.te
+++ b/sepolicy/samsung.te
@@ -2,3 +2,5 @@ type boot_prop, property_type;
 
 set_prop(system_server, boot_prop);
 
+allow hal_camera_default system_prop:property_service { set }
+allow kernel sysfs:file { read open }

--- a/sepolicy/samsung.te
+++ b/sepolicy/samsung.te
@@ -2,3 +2,15 @@ type boot_prop, property_type;
 
 set_prop(system_server, boot_prop);
 
+allow hal_camera_default system_prop:property_service { set }
+allow kernel sysfs:file { read open }
+allow thermal-engine sysfs:dir { search read}
+allow time_daemon sysfs:file { read }
+allow mm-qcamerad sysfs:file { read write }
+allow healthd sysfs:file { read }
+allow hal_audio_default diag_device:chr_file { read write }
+allow system_server userspace_reboot_exported_prop:file { read }
+allow location sysfs:file { read }
+allow atfwd sysfs:file { read }
+allow wcnss_service serialno_prop:file { read }
+allow wcnss_service mnt_vendor_file:dir { write }


### PR DESCRIPTION
I'm not sure if this is the right patch, since this is a GSI, generic. But I'm pretty sure some phones with with qcom chipsets are affected.
If you need some reference, here is /sys/fs/pstore/console-ramoops (because I can't get it boot): 
[console-ramoops.txt](https://github.com/phhusson/device_phh_treble/files/6075772/console-ramoops.txt)

Selinux is enforcing (Samsung Stock Kernel with dm-verity patch)
