### PR TITLE
Fix vendor hostapd detection for manifest fragments

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -724,6 +724,11 @@ for i in odm oem vendor product;do
     if grep -qF android.hardware.wifi.hostapd /$i/etc/vintf/manifest.xml;then
         has_hostapd=true
     fi
+    for j in /$i/etc/vintf/manifest/*;do
+        if grep -qF android.hardware.wifi.hostapd $j;then
+            has_hostapd=true
+        fi
+    done
 done
 
 if [ "$has_hostapd" = false ];then


### PR DESCRIPTION
rw-system.sh doesn't check fragments for hostapd, so for example on my Galaxy A8 with ported Galaxy M31 vendor (and probably on M31, and any other phone which has it as a fragment) which has hostapd defined in `/vendor/etc/vintf/manifest/android.hardware.wifi.hostapd.xml` it tries to use the system hostapd, which fails.

This fixes this problem.