### PR TITLE
Poco M3 fix fingerprint gesture

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -144,7 +144,8 @@ changeKeylayout() {
         -e xiaomi/nitrogen -e xiaomi/sakura -e xiaomi/andromeda \
         -e xiaomi/whyred -e xiaomi/tulip -e xiaomi/onc \
         -e redmi/curtana -e redmi/picasso -e Redmi/lancelot \
-        -e Redmi/galahad -e xiaomi/olive -e Redmi/angelica -e Redmi/joyeuse ; then
+        -e Redmi/galahad -e xiaomi/olive -e Redmi/angelica -e Redmi/joyeuse \
+	-e POCO/citrus; then
         if [ ! -f /mnt/phh/keylayout/uinput-goodix.kl ]; then
           cp /system/phh/empty /mnt/phh/keylayout/uinput-goodix.kl
           chmod 0644 /mnt/phh/keylayout/uinput-goodix.kl


### PR DESCRIPTION
I'm not sure I did it right. The result of `adb shell getprop ro.vendor.build.fingerprint` is:
`POCO/citrus_eea/citrus:10/QKQ1.200830.002/V12.0.7.0.QJFEUXM:user/release-keys`