### PR TITLE
add keylayout for Unihertz devices

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -124,6 +124,10 @@ PRODUCT_COPY_FILES += \
 	device/phh/treble/files/daisy-uinput-fpc.kl:system/phh/daisy-uinput-fpc.kl \
 	device/phh/treble/files/daisy-uinput-goodix.kl:system/phh/daisy-uinput-goodix.kl \
 	device/phh/treble/files/nubia-nubia_synaptics_dsx.kl:system/phh/nubia-nubia_synaptics_dsx.kl \
+	device/phh/treble/files/unihertz-mtk-kpd.kl:system/phh/unihertz-mtk-kpd.kl \
+	device/phh/treble/files/unihertz-mtk-tpd.kl:system/phh/unihertz-mtk-tpd.kl \
+	device/phh/treble/files/unihertz-mtk-tpd-kpd.kl:system/phh/unihertz-mtk-tpd-kpd.kl \
+	device/phh/treble/files/unihertz-fingerprint_key.kl:system/phh/unihertz-fingerprint_key.kl \
 	device/phh/treble/files/zf6-goodixfp.kl:system/phh/zf6-goodixfp.kl \
 	device/phh/treble/files/zf6-googlekey_input.kl:system/phh/zf6-googlekey_input.kl \
 

--- a/files/unihertz-fingerprint_key.kl
+++ b/files/unihertz-fingerprint_key.kl
@@ -1,0 +1,3 @@
+# Key layout for Unihertz devices with fingerprint sensor
+# For Atom {,L,XL}: fingerprint sensor as home
+key 172   HOME   VIRTUAL

--- a/files/unihertz-mtk-kpd.kl
+++ b/files/unihertz-mtk-kpd.kl
@@ -1,0 +1,13 @@
+# Keylayout for Unihertz devices with a dedicated PTT button
+# Volume buttons
+key 115   VOLUME_UP
+key 114   VOLUME_DOWN
+
+# Power button
+key 116   POWER
+
+# PTT - Remap to camera by default
+# CAMERA is delivered to apps, so remapping via
+# third-party apps is possible
+key 249   CAMERA
+key 250   CAMERA

--- a/files/unihertz-mtk-tpd-kpd.kl
+++ b/files/unihertz-mtk-tpd-kpd.kl
@@ -1,0 +1,6 @@
+# Keylayout for Unihertz devices with capacitive keys
+# Capacitive navigation
+key 172   HOME        VIRTUAL
+key 580   APP_SWITCH  VIRTUAL
+key 158   BACK        VIRTUAL
+

--- a/files/unihertz-mtk-tpd.kl
+++ b/files/unihertz-mtk-tpd.kl
@@ -1,0 +1,6 @@
+# Keylayout for Unihertz devices with capacitive keys
+# Capacitive navigation
+key 172   HOME        VIRTUAL
+key 580   APP_SWITCH  VIRTUAL
+key 158   BACK        VIRTUAL
+

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -240,6 +240,18 @@ changeKeylayout() {
         changed=true
     fi
 
+    if getprop ro.vendor.build.fingerprint | grep -q -e Unihertz/;then
+        cp /system/phh/unihertz-mtk-kpd.kl /mnt/phh/keylayout/mtk-kpd.kl
+        cp /system/phh/unihertz-mtk-tpd.kl /mnt/phh/keylayout/mtk-tpd.kl
+        cp /system/phh/unihertz-mtk-tpd-kpd.kl /mnt/phh/keylayout/mtk-tpd-kpd.kl
+        cp /system/phh/unihertz-fingerprint_key.kl /mnt/phh/keylayout/fingerprint_key.kl
+        chmod 0644 /mnt/phh/keylayout/mtk-kpd.kl
+        chmod 0644 /mnt/phh/keylayout/mtk-tpd.kl
+        chmod 0644 /mnt/phh/keylayout/mtk-tpd-kpd.kl
+        chmod 0644 /mnt/phh/keylayout/fingerprint_key.kl
+        changed=true
+    fi
+
     if [ "$changed" = true ]; then
         mount -o bind /mnt/phh/keylayout /system/usr/keylayout
         restorecon -R /system/usr/keylayout


### PR DESCRIPTION
* Unihertz devices have a dedicated PTT button, which I mapped to
  CAMERA, making it useful (kind of) by default and remappable via
  third-party apps.
* Additionally, declare capacitive buttons as VIRTUAL so that vibration
  is applied when they are pressed.