### PR TITLE
BQ Aquaris M10 HD fixes

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -406,6 +406,11 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     setprop  ro.audio.ignore_effects true
 fi
 
+if getprop ro.vendor.build.fingerprint | grep -iq \
+	-e bq/Aquaris_M10 ; then
+	setprop ro.surface_flinger.primary_display_orientation ORIENTATION_90
+fi
+
 if getprop ro.build.fingerprint | grep -iq \
     -e motorola/channel; then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -399,7 +399,8 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     -e motorola/hannah -e motorola/james -e motorola/pettyl -e xiaomi/cepheus \
     -e xiaomi/grus -e xiaomi/cereus -e xiaomi/cactus -e xiaomi/raphael -e xiaomi/davinci \
     -e xiaomi/ginkgo -e xiaomi/laurel_sprout -e xiaomi/andromeda \
-    -e redmi/curtana -e redmi/picasso ; then
+    -e redmi/curtana -e redmi/picasso \
+    -e bq/Aquaris_M10 ; then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx
     setprop  ro.audio.ignore_effects true


### PR DESCRIPTION
* Fixes bootlop because of audio effects.
* Fixes screen orientation (90 degrees).