### PR TITLE
Timekeep for Qualcomm Devices

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -201,3 +201,8 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
 # AOSP overlays
 PRODUCT_PACKAGES += \
     NavigationBarMode2ButtonOverlay
+
+# TimeKeep
+PRODUCT_PACKAGES += \
+    timekeep \
+    TimeKeep

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -19,3 +19,6 @@
 /efs u:object_r:efs_file:s0
 
 /dev/smcinvoke u:object_r:smcinvoke_device:s0
+
+#Timekeep
+/system/bin/gsi_timekeep                     u:object_r:gsi_timekeep_exec:s0

--- a/sepolicy/property_contexts
+++ b/sepolicy/property_contexts
@@ -1,0 +1,1 @@
+persist.sys.timeadjust     u:object_r:timekeep_prop:s0

--- a/sepolicy/qualcomm.te
+++ b/sepolicy/qualcomm.te
@@ -28,3 +28,8 @@ allowxperm tee rpmb_device:blk_file ioctl { 0xb300-0xbfff };
 attribute smcinvoke_device_29_0;
 type smcinvoke_device, dev_type;
 typeattribute smcinvoke_device smcinvoke_device_29_0;
+
+#Timekeep
+type timekeep_prop, property_type;
+allow system_app time_data_file:file rw_file_perms;
+set_prop(system_app, timekeep_prop)

--- a/sepolicy/timekeep.te
+++ b/sepolicy/timekeep.te
@@ -1,0 +1,18 @@
+type gsi_timekeep, domain, domain_deprecated;
+type gsi_timekeep_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(gsi_timekeep)
+
+allow gsi_timekeep self:capability {
+    fowner
+    fsetid
+    sys_time
+    dac_override
+    dac_read_search
+};
+
+allow gsi_timekeep time_data_file:file create_file_perms;
+allow gsi_timekeep time_data_file:dir create_dir_perms;
+
+set_prop(gsi_timekeep, timekeep_prop)

--- a/timekeep.rc
+++ b/timekeep.rc
@@ -1,0 +1,21 @@
+#Timekeep
+on boot
+    # Set system as owner of RTC node
+    chown system system /sys/class/rtc/rtc0/since_epoch
+
+on post-fs-data && property:persist.sys.qcom-timekeep=true
+    # Create folder for timekeep
+    mkdir /data/time 0770 system system
+    mkdir /data/vendor/time 0770 system system
+    chmod 0770 /data/time/ats_2
+    chmod 0770 /data/vendor/time/ats_2
+    start gsi_timekeep
+
+# Time service
+service gsi_timekeep /system/bin/gsi_timekeep restore
+    class late_start
+    user system
+    group system
+    capabilities SYS_TIME
+    disabled
+    writepid /dev/cpuset/system-background/tasks

--- a/vndk.rc
+++ b/vndk.rc
@@ -71,24 +71,4 @@ on property:persist.sys.phh.restart_ril=true
     restart vendor.qcrild2
     restart vendor.ril-daemon-mtk
 
-#Timekeep
-on boot
-    # Set system as owner of RTC node
-    chown system system /sys/class/rtc/rtc0/since_epoch
 
-on post-fs-data && property:persist.sys.qcom-timekeep=true
-    # Create folder for timekeep
-    mkdir /data/time 0770 system system
-    mkdir /data/vendor/time 0770 system system
-    chmod 0770 /data/time/ats_2
-    chmod 0770 /data/vendor/time/ats_2
-    start gsi_timekeep
-
-# Time service
-service gsi_timekeep /system/bin/gsi_timekeep restore
-    class late_start
-    user system
-    group system
-    capabilities SYS_TIME
-    disabled
-    writepid /dev/cpuset/system-background/tasks

--- a/vndk.rc
+++ b/vndk.rc
@@ -70,3 +70,25 @@ on property:persist.sys.phh.restart_ril=true
     restart vendor.qcrild
     restart vendor.qcrild2
     restart vendor.ril-daemon-mtk
+
+#Timekeep
+on boot
+    # Set system as owner of RTC node
+    chown system system /sys/class/rtc/rtc0/since_epoch
+
+on post-fs-data && property:persist.sys.qcom-timekeep=true
+    # Create folder for timekeep
+    mkdir /data/time 0770 system system
+    mkdir /data/vendor/time 0770 system system
+    chmod 0770 /data/time/ats_2
+    chmod 0770 /data/vendor/time/ats_2
+    start gsi_timekeep
+
+# Time service
+service gsi_timekeep /system/bin/gsi_timekeep restore
+    class late_start
+    user system
+    group system
+    capabilities SYS_TIME
+    disabled
+    writepid /dev/cpuset/system-background/tasks


### PR DESCRIPTION
The SE-Policy is used from here and should be working (i only changed binary name):
https://github.com/AICP/device_zuk_z2_plus/commit/8ec17c644d0498ef4e58f0b974961bd3ac30aece

For manifest to build binary i would choose this one:
https://github.com/LineageOS/android_hardware_sony_timekeep
The binary should be "gsi_timekeep".

If this is usable, i would write the PR for treble app checkbox (persist.sys.qcom-timekeep=true).

