### PR TITLE
Use name instead device

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -681,8 +681,8 @@ if [ -f /system/phh/secure ];then
     copyprop ro.product.device ro.product.vendor.device
     copyprop ro.product.system.name ro.vendor.product.name
     copyprop ro.product.name ro.vendor.product.name
-    copyprop ro.product.system.name ro.product.vendor.device
-    copyprop ro.product.name ro.product.vendor.device
+    copyprop ro.product.system.name ro.product.vendor.name
+    copyprop ro.product.name ro.product.vendor.name
     copyprop ro.system.product.brand ro.vendor.product.brand
     copyprop ro.product.brand ro.vendor.product.brand
     copyprop ro.product.system.model ro.vendor.product.model


### PR DESCRIPTION
On some devices, device and name use different values, which prevents the safetynet test from passing