### PR TITLE
[Huawei P10] Extend the fingerprint for stopping aptouch

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -997,6 +997,6 @@ if [ "$(stat -c '%U'  /dev/nxp_smartpa_dev)" == "root" ] &&
     chown root:audio /dev/nxp_smartpa_dev
     chmod 0660 /dev/nxp_smartpa_dev
 fi
-if getprop ro.odm.build.fingerprint |grep -q Huawei/Chicago;then
+if getprop ro.odm.build.fingerprint |grep -q Huawei/Chicago/Chicago_VTR;then
     setprop ctl.stop aptouch
 fi


### PR DESCRIPTION
Make it only apply to the P10 and not to all Kirin 960 devices.