### PR TITLE
Add Netflix ID for Mi 11 lite 5G

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -959,6 +959,10 @@ if getprop ro.vendor.build.fingerprint |grep -qi redmi/curtana;then
     setprop ro.netflix.bsp_rev Q6250-19132-1
 fi
 
+if getprop ro.vendor.build.fingerprint |grep -iq xiaomi/renoir;then
+    setprop ro.netflix.bsp_rev Q875-32774-1
+fi
+
 # Set props for Vsmart Live's fod
 if getprop ro.vendor.build.fingerprint |grep -q vsmart/V620A_open;then
     setprop persist.sys.fp.fod.location.X_Y 447,1812


### PR DESCRIPTION
Add Netflix ID for Widevine L1 support in Netflix.