### PR TITLE
Remove Mi 11 Lite 5G (renoir) from the audio effects fix

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -441,7 +441,6 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     -e motorola/hannah -e motorola/james -e motorola/pettyl -e xiaomi/cepheus \
     -e xiaomi/grus -e xiaomi/cereus -e xiaomi/cactus -e xiaomi/raphael -e xiaomi/davinci \
     -e xiaomi/ginkgo -e xiaomi/willow -e xiaomi/laurel_sprout -e xiaomi/andromeda \
-    -e iaomi/renoir \
     -e redmi/curtana -e redmi/picasso \
     -e bq/Aquaris_M10 ; then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx


### PR DESCRIPTION
This should be replaced by the sound volume fix on the Qualcomm page of the TrebleApp