### PR TITLE
Disable fingerprint gestures for Stylo 7 4G variant

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -275,7 +275,7 @@ changeKeylayout() {
         changed=true
     fi
 
-    if getprop ro.product.vendor.device |grep -qi mfh505glm; then
+    if getprop ro.product.vendor.device |grep -qi -e mfh505glm -e fh50lm; then
         cp /system/phh/empty /mnt/phh/keylayout/uinput-fpc.kl
         chmod 0644 /mnt/phh/keylayout/uinput-fpc.kl
         changed=true


### PR DESCRIPTION
Stylo 7 4G has the same problem as Stylo 7 5G with unnecessary fingerprint gestures, so I added Stylo 7 4G as well.