### PR TITLE
[Motorola One Fusion+] Fix bluetooth audio

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1058,3 +1058,11 @@ fi
 if getprop ro.vendor.build.fingerprint | grep -qi -e iaomi/mona; then
     copyprop ro.product.manufacturer ro.product.vendor.manufacturer
 fi
+
+if getprop ro.vendor.build.fingerprint | grep -iq -e motorola/liber; then
+  cp /vendor/etc/audio_policy_configuration.xml /mnt/phh/
+  sed -i '198i <xi:include href="/vendor/etc/a2dp_audio_policy_configuration.xml"/>' /mnt/phh/audio_policy_configuration.xml
+  mount -o bind /mnt/phh/audio_policy_configuration.xml /vendor/etc/audio_policy_configuration.xml
+  chcon -h u:object_r:vendor_configs_file:s0 /vendor/etc/audio_policy_configuration.xml
+  chmod 644 /vendor/etc/audio_policy_configuration.xml
+fi

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1061,7 +1061,7 @@ fi
 
 if getprop ro.vendor.build.fingerprint | grep -iq -e motorola/liber; then
   cp /vendor/etc/audio_policy_configuration.xml /mnt/phh/
-  sed -i '198i <xi:include href="/vendor/etc/a2dp_audio_policy_configuration.xml"/>' /mnt/phh/audio_policy_configuration.xml
+  sed -i '/r_submix_audio_policy_configuration/a \t<xi:include href="/vendor/etc/a2dp_audio_policy_configuration.xml"/>' /mnt/phh/audio_policy_configuration.xml
   mount -o bind /mnt/phh/audio_policy_configuration.xml /vendor/etc/audio_policy_configuration.xml
   chcon -h u:object_r:vendor_configs_file:s0 /vendor/etc/audio_policy_configuration.xml
   chmod 644 /vendor/etc/audio_policy_configuration.xml


### PR DESCRIPTION
**Required Phh Treble Settings:**
- Use alternate audio policy
- Disable audio effects
- Force-disable A2DP offload

Tested on v400.h and Pixel Experience 12.0 v402.1