### PR TITLE
Update oplus fp manifest location for a12 vendor

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -346,7 +346,7 @@ if grep vendor.huawei.hardware.biometrics.fingerprint /vendor/manifest.xml; then
 fi
 
 foundFingerprint=false
-for manifest in /vendor/manifest.xml /vendor/etc/vintf/manifest.xml /odm/etc/vintf/manifest.xml;do
+for manifest in /vendor/manifest.xml /vendor/etc/vintf/manifest.xml /odm/etc/vintf/manifest.xml /odm/etc/vintf/manifest/manifest_oplus_fingerprint.xml;do
     if grep -q \
             -e android.hardware.biometrics.fingerprint \
             -e vendor.oppo.hardware.biometrics.fingerprint \


### PR DESCRIPTION
https://dumps.tadiphone.dev/dumps/oplus/op516e/-/blob/qssi-user-12-SKQ1.211019.001-1646580650864-release-keys/odm/etc/vintf/manifest/manifest_oplus_fingerprint.xml