### PR TITLE
Update rw-system.sh for Galaxy A11 watchdog quirk

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1010,6 +1010,10 @@ fi
 # Disable secondary watchdogs
 echo -n V > /dev/watchdog1
 
+if getprop ro.vendor.build.fingerprint | grep -iq samsung/a11que;then
+	echo -n V > /dev/watchdog0
+fi
+	
 if [ "$vndk" -le 30 ];then
 	# On older vendor the default behavior was to disable color management
 	# Don't override vendor value, merely add a fallback


### PR DESCRIPTION
Fixes a panic 100 seconds into boot, caused by /dev/watchdog0 (/dev/watchdog1 was already accounted for). 
Works for the Samsung Galaxy A11, US model (SM-A115U1, a11que), so it's written to play it safe and apply only to the US vendor fingerprint.