### PR TITLE
a20s: Fix watchdog issue

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -1016,6 +1016,11 @@ fi
 # Disable secondary watchdogs
 echo -n V > /dev/watchdog1
 
+# Fix watchdog issue on Samsung Galaxy A20s
+if getprop ro.vendor.build.fingerprint | grep -iq samsung/a20sub/a20s; then
+    echo -n V > /dev/watchdog0
+fi
+
 if getprop ro.vendor.build.fingerprint | grep -iq samsung/a11que;then
 	echo -n V > /dev/watchdog0
 fi


### PR DESCRIPTION
This commit fixes the Watchdog Timer Software problem by disabling it.

When the Watchdog Timer expires or crashes causes the device (in this case: Samsung Galaxy A20s) to reboot, and is fixed by just disabling it.

An example of kernel panic log:
[  115.680218] I[5:IntentService[D: 5621] Kernel panic - not syncing: Software Watchdog Timer expired
[  117.139710] I[5:IntentService[D: 5621] sec_debug_panic_handler :Software Watchdog Timer expired
[  117.141840] Causing a watchdog bite!

GSI used to test whether the problem has been fixed: https://sourceforge.net/projects/gsi-projects/files/v413/ArrowOS-12.1/ArrowOS-12.1-arm64_bgN-vndklite-Unofficial.img.xz/download
Screenshot: https://imgur.com/a/7eit2Le

Signed-off-by: Hakalle <hakalle@proton.me>