### PR TITLE
Set persist.sys.phh.ultrasonic_udfps to true for S21(+/Ultra) (Exynos)

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -942,6 +942,10 @@ if getprop ro.vendor.build.fingerprint |grep -qiE '^samsung/';then
     setprop persist.sys.phh.fod.samsung true
 fi
 
+if getprop ro.vendor.build.fingerprint | grep -q -e samsung/o1s -e samsung/t2s -e samsung/p3s; then
+    setprop persist.sys.phh.ultrasonic_udfps true
+fi
+
 if getprop ro.vendor.build.fingerprint |grep -qiE -e ASUS_I006D -e ASUS_I003;then
 	setprop persist.sys.phh.fod.asus true
 fi


### PR DESCRIPTION
Gets rid of the unnecessary FOD light when using ultrasonic sensor on the above devices. Tested & Confirmed to be working as intended.