### PR TITLE
allow deskclock to run in the background

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -232,3 +232,7 @@ PRODUCT_COPY_FILES += \
 	frameworks/av/services/audiopolicy/config/a2dp_audio_policy_configuration.xml:system/etc/a2dp_audio_policy_configuration.xml \
 
 include build/make/target/product/gsi_release.mk
+
+# Protect deskclock from power save
+PRODUCT_COPY_FILES += \
+	device/phh/treble/files/com.android.deskclock_whitelist.xml:system/etc/sysconfig/com.android.deskclock_whitelist.xml

--- a/files/com.android.deskclock_whitelist.xml
+++ b/files/com.android.deskclock_whitelist.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2019-2020 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<config>
+    <allow-in-power-save package="com.android.deskclock" />
+</config>


### PR DESCRIPTION
https://github.com/LineageOS/android_packages_apps_DeskClock/commit/8dd096c4cfb647960be1695a57246727878b8c8d

Should allow alarm clock to work consistently