### PR TITLE
disable setup wizard in gapps builds until it no longer breaks fingerprint enrollment

### DIFF
--- a/files/gapps_bandaid
+++ b/files/gapps_bandaid
@@ -1,0 +1,19 @@
+#!/system/bin/sh
+
+# hide setup wizard from system
+if [ "$1" == "mask_sw" ] && [ "$(getprop persist.sys.phh.mask_sw)" != "0" ]
+then
+	mount -t tmpfs -o ro none /system/system_ext/priv-app/SetupWizard/
+fi
+
+# set setup wizard to completed
+if [ "$1" == "set_sw_completed" ] && [ "$(getprop persist.sys.phh.set_sw_compelted)" != "0" ]
+then
+	settings put global setup_wizard_has_run 1
+	settings put secure user_setup_complete 1
+	settings put global device_provisioned 1
+	setprop persist.sys.phh.set_sw_compelted 0
+fi
+
+
+

--- a/files/gapps_bandaid.rc
+++ b/files/gapps_bandaid.rc
@@ -1,0 +1,19 @@
+on zygote-start
+    start gapps_bandaid_mask_sw
+
+on property:sys.boot_completed=1
+    start gapps_bandaid_set_sw_completed
+
+service gapps_bandaid_mask_sw /system/bin/gapps_bandaid mask_sw
+    disabled
+    oneshot  
+    user root 
+    group root
+    seclabel u:r:su:s0
+
+service gapps_bandaid_set_sw_completed /system/bin/gapps_bandaid set_sw_completed
+    disabled
+    oneshot  
+    user root 
+    group root
+    seclabel u:r:su:s0

--- a/gapps-go.mk
+++ b/gapps-go.mk
@@ -19,3 +19,8 @@ PRODUCT_SHIPPING_API_LEVEL :=
 PRODUCT_PACKAGES += \
 	phh-gapps-go-overrides \
 	GoogleContactsSyncAdapter \
+
+# Disable SetupWizard, until working SetupWizard that does not break fingerprint enrollment introduction is found
+PRODUCT_COPY_FILES += \
+	device/phh/treble/files/gapps_bandaid.rc:system/etc/init/gapps_bandaid.rc \
+	device/phh/treble/files/gapps_bandaid:system/bin/gapps_bandaid

--- a/gapps.mk
+++ b/gapps.mk
@@ -50,3 +50,8 @@ PRODUCT_PACKAGES += \
 	   com.simplemobiletools.gallery.pro \
 
 endif
+
+# Disable SetupWizard, until working SetupWizard that does not break fingerprint enrollment introduction is found
+PRODUCT_COPY_FILES += \
+	device/phh/treble/files/gapps_bandaid.rc:system/etc/init/gapps_bandaid.rc \
+	device/phh/treble/files/gapps_bandaid:system/bin/gapps_bandaid


### PR DESCRIPTION
can be toggled with props, can't find a good timing for pm disable so mount is used

https://github.com/phhusson/treble_experimentations/issues/2269