### PR TITLE
Include vendor.xiaomi.hardware.displayfeature

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -102,6 +102,7 @@ PRODUCT_PACKAGES += \
 	vendor.huawei.hardware.tp-V1.0-java \
 	vendor.qti.hardware.radio.am-V1.0-java \
 	vendor.qti.qcril.am-V1.0-java \
+	vendor.xiaomi.hardware.displayfeature-V1.0-java
 
 PRODUCT_COPY_FILES += \
 	device/phh/treble/interfaces.xml:system/etc/permissions/interfaces.xml

--- a/interfaces.xml
+++ b/interfaces.xml
@@ -12,4 +12,6 @@
 		file="/system/framework/vendor.huawei.hardware.tp-V1.0-java.jar" />
     <library name="android.hardware.wifi.hostapd.V1_0"
         file="/system/framework/android.hardware.wifi.hostapd-V1.0-java.jar" />
+	<library name="vendor.xiaomi.hardware.displayfeature.V1_0"
+		file="/system/framework/vendor.xiaomi.hardware.displayfeature-V1.0-java.jar" />
 </permissions>


### PR DESCRIPTION
Needed to disable Xiaomi's Sunlight Mode which triggers some constrast/color issues on AOSP
Remove some white space too

To be used with https://github.com/phhusson/treble_app/pull/70