### PR TITLE
Fix persist.sys.sf.hs_mode prop denial on exynos2100 devices

### DIFF
--- a/sepolicy/property_contexts
+++ b/sepolicy/property_contexts
@@ -1,0 +1,1 @@
+persist.sys.sf.hs_mode         u:object_r:sf_hs_mode_prop:s0

--- a/sepolicy/samsung.te
+++ b/sepolicy/samsung.te
@@ -2,3 +2,8 @@ type boot_prop, property_type;
 
 set_prop(system_server, boot_prop);
 
+type hal_graphics_composer_default, domain;
+
+type sf_hs_mode_prop, property_type;
+
+get_prop(hal_graphics_composer_default, sf_hs_mode_prop);


### PR DESCRIPTION
This will allow GSI to be booted on exynos2100 devices with enforcing kernel and have proper framerates. 
Fixes this issue https://github.com/phhusson/treble_experimentations/issues/2135#issuecomment-1140166172