### PR TITLE
Fixes for Xiaomi Mi 10T Lite/Mi 10i/Redmi Note 9 Pro

### DIFF
--- a/rw-system.sh
+++ b/rw-system.sh
@@ -392,9 +392,9 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     setprop persist.sys.qcom-brightness -1
 fi
 
-# Lenovo Z5s brightness flickers without this setting
+# Lenovo Z5s & Xiaomi Mi10TLite brightness flickers without this setting
 if getprop ro.vendor.build.fingerprint | grep -iq \
-    -e Lenovo/jd2019; then
+    -e Lenovo/jd2019 -e Xiaomi/gauguin -e Redmi/gauguinpro; then
     setprop persist.sys.qcom-brightness -1
 fi
 

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -394,7 +394,7 @@ fi
 
 # Lenovo Z5s & Xiaomi Mi10TLite brightness flickers without this setting
 if getprop ro.vendor.build.fingerprint | grep -iq \
-    -e Lenovo/jd2019 -e Xiaomi/gauguin -e Redmi/gauguinpro; then
+    -e Lenovo/jd2019 -e Xiaomi/gauguin -e Redmi/gauguin; then
     setprop persist.sys.qcom-brightness -1
 fi
 
@@ -457,7 +457,7 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     -e motorola/hannah -e motorola/james -e motorola/pettyl -e xiaomi/cepheus \
     -e xiaomi/grus -e xiaomi/cereus -e xiaomi/cactus -e xiaomi/raphael -e xiaomi/davinci \
     -e xiaomi/ginkgo -e xiaomi/willow -e xiaomi/laurel_sprout -e xiaomi/andromeda \
-    -e xiaomi/gauguin -e redmi/gauguinpro -e redmi/curtana -e redmi/picasso \
+    -e xiaomi/gauguin -e redmi/gauguin -e redmi/curtana -e redmi/picasso \
     -e bq/Aquaris_M10 ; then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx

--- a/rw-system.sh
+++ b/rw-system.sh
@@ -457,7 +457,7 @@ if getprop ro.vendor.build.fingerprint | grep -iq \
     -e motorola/hannah -e motorola/james -e motorola/pettyl -e xiaomi/cepheus \
     -e xiaomi/grus -e xiaomi/cereus -e xiaomi/cactus -e xiaomi/raphael -e xiaomi/davinci \
     -e xiaomi/ginkgo -e xiaomi/willow -e xiaomi/laurel_sprout -e xiaomi/andromeda \
-    -e redmi/curtana -e redmi/picasso \
+    -e xiaomi/gauguin -e redmi/gauguinpro -e redmi/curtana -e redmi/picasso \
     -e bq/Aquaris_M10 ; then
     mount -o bind /mnt/phh/empty_dir /vendor/lib64/soundfx
     mount -o bind /mnt/phh/empty_dir /vendor/lib/soundfx


### PR DESCRIPTION
Tested on vendor `V13.0.5.0.SJSCNXM_20220510`

--------------------------------------------

Unresolved:

1. ~~Wired headphone can't be detected~~
  UPDATE: Enable "Use alternate audio policy" can fix this issue
  ```
  09-17 03:09:11.509  2257  2257 E APM::HwModule: createDevice: could not find HW module for device 0004 address
  09-17 03:09:11.510  2224  2791 E AudioSystem-JNI: Command failed for android_media_AudioSystem_setDeviceConnectionState: -38
  09-17 03:09:11.510  2224  2791 E AS.AudioDeviceInventory: not connecting device 0x4 due to command error 1
  09-17 03:09:11.515  2257  2257 E APM::HwModule: createDevice: could not find HW module for device 80000010 address
  09-17 03:09:11.516  2224  2791 E AudioSystem-JNI: Command failed for android_media_AudioSystem_setDeviceConnectionState: -38
  09-17 03:09:11.516  2224  2791 E AS.AudioDeviceInventory: not connecting device 0x80000010 due to command error 1
  ```
3. ~~Bluetooth can't connect to A2DP devices~~
   UPDATE: Phh Treble Settings -> Misc features -> Force-disable A2DP offload
  ```
09-17 03:14:53.583  2829  3491 I bt_stack: [INFO:a2dp_encoding.cc(349)] init
09-17 03:14:53.583  2829  3491 W bt_stack: [WARNING:a2dp_encoding.cc(361)] init: BluetoothAudio HAL for A2DP is invalid?!
09-17 03:14:53.583  2829  3491 W bt_stack: [WARNING:btif_a2dp_source.cc(366)] btif_a2dp_source_startup_delayed: Using BluetoothA2dp HAL
09-17 03:14:53.583  2829  3491 I bt_btif_a2dp_source: system/bt/btif/src/btif_a2dp_source.cc:1018 btif_a2dp_source_audio_tx_flush_event: btif_a2dp_source_audio_tx_flush_event: state=STATE_RUNNING
09-17 03:14:53.583  2829  3491 I bt_btif_a2dp_source: system/bt/btif/src/btif_a2dp_source.cc:569 btif_a2dp_source_setup_codec_delayed: btif_a2dp_source_setup_codec_delayed: peer_address=**:**:**:**:**:** state=STATE_RUNNING
09-17 03:14:53.584  2829  3491 I bt_stack: [INFO:bta_av_co.cc(1440)] SetActivePeer: codec = 	name: SBC
09-17 03:14:53.584  2829  3491 I bt_stack: 	samp_freq: 44100 (0x20)
09-17 03:14:53.584  2829  3491 I bt_stack: 	ch_mode: Joint (0x01)
09-17 03:14:53.584  2829  3491 I bt_stack: 	block_len: 16 (0x10)
09-17 03:14:53.584  2829  3491 I bt_stack: 	num_subbands: 8 (0x04)
09-17 03:14:53.584  2829  3491 I bt_stack: 	alloc_method: Loundess (0x01)
09-17 03:14:53.584  2829  3491 I bt_stack: 	Bit pool Min: 2 Max: 53
09-17 03:14:53.584  2829  3491 I bt_stack: [INFO:bta_av_co.cc(1661)] ReportSourceCodecState: peer **:**:**:**:**:** codec_config={codec: SBC priority: 1001 sample_rate: 44100 bits_per_sample: 16 channel_mode: STEREO codec_specific_1: 0 codec_specific_2: 0 codec_specific_3: 0 codec_specific_4: 0}
09-17 03:14:53.584  2829  3491 I a2dp_sbc_encoder: system/bt/stack/a2dp/a2dp_sbc_encoder.cc:221 a2dp_sbc_encoder_update: a2dp_sbc_encoder_update: sample_rate=44100 bits_per_sample=16 channel_count=2
09-17 03:14:53.584  2829  3491 I a2dp_sbc_encoder: system/bt/stack/a2dp/a2dp_sbc_encoder.cc:387 a2dp_sbc_feeding_reset: a2dp_sbc_feeding_reset: PCM bytes per tick 3528
09-17 03:14:53.584  2829  3491 I a2dp_sbc_encoder: system/bt/stack/a2dp/a2dp_sbc_encoder.cc:273 a2dp_sbc_encoder_update: a2dp_sbc_encoder_update: MTU=660, peer_mtu=660 min_bitpool=2 max_bitpool=53
09-17 03:14:53.584  2829  3491 I a2dp_sbc_encoder: system/bt/stack/a2dp/a2dp_sbc_encoder.cc:280 a2dp_sbc_encoder_update: a2dp_sbc_encoder_update: ChannelMode=3, NumOfSubBands=8, NumOfBlocks=16, AllocationMethod=0, BitRate=328, SamplingFreq=44100 BitPool=0
09-17 03:14:53.584  2829  3491 I a2dp_sbc_encoder: system/bt/stack/a2dp/a2dp_sbc_encoder.cc:363 a2dp_sbc_encoder_update: a2dp_sbc_encoder_update: final bit rate 328, final bit pool 53
09-17 03:14:53.584  2829  3491 I bt_stack: [INFO:btif_a2dp_source.cc(396)] btif_a2dp_source_start_session_delayed: peer_address=**:**:**:**:**:** state=STATE_RUNNING
09-17 03:14:53.584  2829  3491 I btif_a2dp_audio_interface: system/bt/btif/src/btif_a2dp_audio_interface.cc:295 btif_a2dp_audio_interface_start_session: btif_a2dp_audio_interface_start_session
09-17 03:14:53.584  2829  3491 I btif_a2dp_audio_interface: system/bt/btif/src/btif_a2dp_audio_interface.cc:266 btif_a2dp_audio_interface_init: btif_a2dp_audio_interface_init
09-17 03:14:53.584  3177  3177 D CachedBluetoothDevice: onProfileStateChanged: profile A2DP, device MATRIX, newProfileState 2
09-17 03:14:53.584  2846  3091 D CachedBluetoothDevice: onProfileStateChanged: profile A2DP, device MATRIX, newProfileState 2
09-17 03:14:53.585   564   564 I hwservicemanager: getTransport: Cannot find entry android.hardware.bluetooth.a2dp@1.0::IBluetoothAudioOffload/default in either framework or device VINTF manifest.
09-17 03:14:53.586  2829  2971 I BluetoothA2dpServiceJni: bta2dp_audio_config_callback
09-17 03:14:53.587  2829  2971 D A2dpNativeInterface: onCodecConfigChanged: A2dpStackEvent {type:EVENT_TYPE_CODEC_CONFIG_CHANGED, device:**:**:**:**:**:**, value1:0, codecStatus:{mCodecConfig:{codecName:SBC,mCodecType:0,mCodecPriority:1001,mSampleRate:0x1(44100),mBitsPerSample:0x1(16),mChannelMode:0x2(STEREO),mCodecSpecific1:0,mCodecSpecific2:0,mCodecSpecific3:0,mCodecSpecific4:0},mCodecsLocalCapabilities:[{codecName:LDAC,mCodecType:4,mCodecPriority:5001,mSampleRate:0xf(44100|48000|88200|96000),mBitsPerSample:0x7(16|24|32),mChannelMode:0x2(STEREO),mCodecSpecific1:0,mCodecSpecific2:0,mCodecSpecific3:0,mCodecSpecific4:0}, {codecName:AAC,mCodecType:1,mCodecPriority:2001,mSampleRate:0x1(44100),mBitsPerSample:0x1(16),mChannelMode:0x2(STEREO),mCodecSpecific1:0,mCodecSpecific2:0,mCodecSpecific3:0,mCodecSpecific4:0}, {codecName:SBC,mCodecType:0,mCodecPriority:1001,mSampleRate:0x1(44100),mBitsPerSample:0x1(16),mChannelMode:0x3(MONO|STEREO),mCodecSpecific1:0,mCodecSpecific2:0,mCodecSpecific3:0,mCodecSpecific4:0}],mCodecsSelectableCapabilities:[{codecName:SBC,mCodecType:0,mCodecPriority:1001,mSampleRate:0x1(44100),mBitsPerSample:0x1(16),mChannelMode:0x3(MONO|STEREO),mCodecSpecific1:0,mCodecSpecific2:0,mCodecSpecific3:0,mCodecSpecific4:0}]}}
09-17 03:14:53.598  2398  2398 D MediaRouterService: GlobalBluetoothA2dpOn is changed to 'true'
09-17 03:14:53.602  2829  3481 I bt_stack: [INFO:btsnoop.cc(295)] allowlist_l2c_channel: Allowlisting l2cap channel. conn_handle=5 cid=0x0047:0x0043
09-17 03:14:53.611  2829  3491 F bt_stack: [FATAL:btif_a2dp_audio_interface.cc(269)] Check failed: btAudio != nullptr. 
09-17 03:14:53.611  2829  3491 F bt_stack: #00 0x000000728fef290f /system/lib64/libchrome.so+0x00000000000bb90f
09-17 03:14:53.611  2829  3491 F bt_stack: #01 0x000000728cfc183b /system/lib64/libbluetooth.so+0x000000000028b83b
09-17 03:14:53.611  2829  3491 F bt_stack: #02 0x000000728cfc7047 /system/lib64/libbluetooth.so+0x0000000000291047
09-17 03:14:53.611  2829  3491 F bt_stack: #03 0x000000728cfcb6c7 /system/lib64/libbluetooth.so+0x00000000002956c7
09-17 03:14:53.611  2829  3491 F bt_stack: #04 0x000000728feda497 /system/lib64/libchrome.so+0x00000000000a3497
09-17 03:14:53.611  2829  3491 F bt_stack: #05 0x000000728fef8fe7 /system/lib64/libchrome.so+0x00000000000c1fe7
09-17 03:14:53.611  2829  3491 F bt_stack: #06 0x000000728fef9383 /system/lib64/libchrome.so+0x00000000000c2383
09-17 03:14:53.611  2829  3491 F bt_stack: #07 0x000000728fefa567 /system/lib64/libchrome.so+0x00000000000c3567
09-17 03:14:53.611  2829  3491 F bt_stack: #08 0x000000728ff1c1bb /system/lib64/libchrome.so+0x00000000000e51bb
09-17 03:14:53.611  2829  3491 F bt_stack: #09 0x000000728cf6887f /system/lib64/libbluetooth.so+0x000000000023287f
09-17 03:14:53.611  2829  3491 F bt_stack: #10 0x000000728cf682bf /system/lib64/libbluetooth.so+0x00000000002322bf
09-17 03:14:53.611  2829  3491 F bt_stack: #11 0x000000728cf68d8f /system/lib64/libbluetooth.so+0x0000000000232d8f
09-17 03:14:53.611  2829  3491 F bt_stack: #12 0x00000075b087aa53 /apex/com.android.runtime/lib64/bionic/libc.so+0x00000000000b1a53
09-17 03:14:53.611  2829  3491 F bt_stack: #13 0x00000075b081a52f /apex/com.android.runtime/lib64/bionic/libc.so+0x000000000005152f
09-17 03:14:53.611  2829  3491 F bt_stack: 
09-17 03:14:53.612  2829  3491 F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 3491 (bt_a2dp_source_), pid 2829 (droid.bluetooth)
  ```